### PR TITLE
Fix `validateKeyPassword()` types

### DIFF
--- a/documentation/collection/main/reference/api/server-api.md
+++ b/documentation/collection/main/reference/api/server-api.md
@@ -809,7 +809,7 @@ const validateKeyPassword: (
 	providerId: string,
 	providerUserId: string,
 	password: string
-) => Promise<User>;
+) => Promise<Key>;
 ```
 
 #### Parameter

--- a/packages/lucia-auth/CHANGELOG.md
+++ b/packages/lucia-auth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.6.1
+
+- Fix `validateKeyPassword` types
+
 ## 0.6.0
 
 - [Breaking] Update `UserAdapter`

--- a/packages/lucia-auth/package.json
+++ b/packages/lucia-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia-auth",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "A simple yet flexible authentication library",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/lucia-auth/src/auth/index.ts
+++ b/packages/lucia-auth/src/auth/index.ts
@@ -204,7 +204,7 @@ export class Auth<C extends Configurations = any> {
 		providerId: string,
 		providerUserId: string,
 		password: string
-	): Promise<User> => {
+	): Promise<Key> => {
 		const keyId = `${providerId}:${providerUserId}`;
 		const databaseKeyData = await this.adapter.getKey(keyId);
 		if (!databaseKeyData) throw new LuciaError("AUTH_INVALID_KEY_ID");


### PR DESCRIPTION
Fixed incorrect return type and documentation of `validateKeyPassword()`