### PR TITLE
fix: export provider types to avoid TS4029 in CommonJs projects with --declarations flag set

### DIFF
--- a/packages/integration-oauth/src/github.ts
+++ b/packages/integration-oauth/src/github.ts
@@ -9,9 +9,9 @@ import {
 	OAuthProvider
 } from "./index.js";
 
-interface Configs extends OAuthConfig {}
+export interface Configs extends OAuthConfig {}
 
-class Github<A extends Auth> implements OAuthProvider<A> {
+export class Github<A extends Auth> implements OAuthProvider<A> {
 	constructor(auth: A, configs: Configs) {
 		this.auth = auth;
 		this.clientId = configs.clientId;
@@ -107,7 +107,7 @@ const github = <A extends Auth>(auth: A, configs: Configs) => {
 
 export default github;
 
-interface GithubUser {
+export interface GithubUser {
 	login: string;
 	id: number;
 	node_id: string;

--- a/packages/integration-oauth/src/google.ts
+++ b/packages/integration-oauth/src/google.ts
@@ -9,11 +9,11 @@ import {
 	OAuthProvider
 } from "./index.js";
 
-interface Configs extends OAuthConfig {
+export interface Configs extends OAuthConfig {
 	redirectUri: string;
 }
 
-class Google<A extends Auth> implements OAuthProvider<A> {
+export class Google<A extends Auth> implements OAuthProvider<A> {
 	constructor(auth: A, configs: Configs) {
 		this.auth = auth;
 		this.clientId = configs.clientId;
@@ -129,7 +129,7 @@ const google = <A extends Auth>(auth: A, configs: Configs) => {
 
 export default google;
 
-interface GoogleUser {
+export interface GoogleUser {
 	sub: string;
 	name: string;
 	given_name: string;

--- a/packages/integration-oauth/src/patreon.ts
+++ b/packages/integration-oauth/src/patreon.ts
@@ -9,12 +9,12 @@ import {
 	OAuthProvider
 } from "./index.js";
 
-interface Configs extends OAuthConfig {
+export interface Configs extends OAuthConfig {
 	redirectUri: string;
 	allMemberships?: boolean;
 }
 
-class Patreon<A extends Auth> implements OAuthProvider<A> {
+export class Patreon<A extends Auth> implements OAuthProvider<A> {
 	constructor(auth: A, configs: Configs) {
 		this.auth = auth;
 		this.clientId = configs.clientId;
@@ -227,7 +227,7 @@ interface PatreonMembershipRaw {
 		};
 	};
 }
-interface PatreonUser {
+export interface PatreonUser {
 	type: "user";
 	attributes: {
 		about: string | null;

--- a/packages/integration-oauth/src/reddit.ts
+++ b/packages/integration-oauth/src/reddit.ts
@@ -9,7 +9,7 @@ import {
 	CreateUserAttributesParameter
 } from "./index.js";
 
-interface Configs extends OAuthConfig {
+export interface Configs extends OAuthConfig {
 	redirectUri: string;
 }
 
@@ -29,7 +29,7 @@ const encodeBase64 = (s: string) => {
 	return btoa(s);
 };
 
-class Reddit<A extends Auth> implements OAuthProvider<A> {
+export class Reddit<A extends Auth> implements OAuthProvider<A> {
 	constructor(auth: A, configs: Configs) {
 		this.auth = auth;
 		this.clientId = configs.clientId;
@@ -135,7 +135,7 @@ const reddit = <A extends Auth>(auth: A, configs: Configs) => {
 
 export default reddit;
 
-interface RedditUser {
+export interface RedditUser {
 	is_employee: boolean;
 	seen_layout_switch: boolean;
 	has_visited_new_profile: boolean;

--- a/packages/integration-oauth/src/twitch.ts
+++ b/packages/integration-oauth/src/twitch.ts
@@ -9,12 +9,12 @@ import {
 	OAuthProvider
 } from "./index.js";
 
-interface Configs extends OAuthConfig {
+export interface Configs extends OAuthConfig {
 	redirectUri: string;
 	forceVerify?: boolean;
 }
 
-class Twitch<A extends Auth> implements OAuthProvider<A> {
+export class Twitch<A extends Auth> implements OAuthProvider<A> {
 	constructor(auth: A, configs: Configs) {
 		this.auth = auth;
 		this.clientId = configs.clientId;
@@ -132,7 +132,7 @@ const twitch = <A extends Auth>(auth: A, configs: Configs) => {
 
 export default twitch;
 
-interface TwitchUser {
+export interface TwitchUser {
 	id: string;
 	login: string;
 	display_name: string;


### PR DESCRIPTION
In NestJS you are required to use `"module": "CommonJS"` so `import()` is needed to import luicia, however this throws the following error at build time:
```
error TS4029: Public property 'google' of exported class has or is using name 'GoogleUser' from external module "[...]/node_modules/.pnpm/@lucia-auth+oauth@0.5.2_lucia-auth@0.6.2/node_modules/@lucia-auth/oauth/google" but cannot be named.
```
Exporting the types seem to fix these problems.

Ideally the library would be made CJS compatible but I understand if that's not a priority