### PR TITLE
fix: Discord oauth provider uses "identify" scope instead of "identity"

### DIFF
--- a/documentation/collection/integration/oauth/providers/discord.md
+++ b/documentation/collection/integration/oauth/providers/discord.md
@@ -9,7 +9,7 @@ OAuth integration for Discord. Refer to [Discord API documentation](https://disc
 import { discord } from "@lucia-auth/oauth/providers";
 ```
 
-The `identity` scope is always included regardless of provided `scope` config.
+The `identify` scope is always included regardless of provided `scope` config.
 
 ### Initialization
 
@@ -40,7 +40,7 @@ const discord: (
 | config.clientId     | `string`                                    | Github OAuth app client id                         |          |
 | config.clientSecret | `string`                                    | Github OAuth app client secret                     |          |
 | configs.redirectUri | `string`                                    | an authorized redirect URI                         |          |
-| config.scope        | `string[]`                                  | an array of scopes - `identity` is always included | true     |
+| config.scope        | `string[]`                                  | an array of scopes - `identify` is always included | true     |
 
 #### Returns
 

--- a/packages/integration-oauth/src/providers/discord.ts
+++ b/packages/integration-oauth/src/providers/discord.ts
@@ -15,7 +15,7 @@ export const discord = (auth: Auth, config: Config) => {
 		const url = createUrl("https://discord.com/oauth2/authorize", {
 			response_type: "code",
 			client_id: config.clientId,
-			scope: scope(["identity"], config.scope),
+			scope: scope(["identify"], config.scope),
 			redirect_uri: config.redirectUri,
 			state
 		});


### PR DESCRIPTION
# "Identify" instead of "identity"
The default scope for the Discord provider was set to "identity" but it should be "identify". The [documentation](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes) says to use "identify".

### Problem: 
Discord was rejecting oauth authorization with the following message: "Invalid scope: identity"

### Solution
Change "identity" to "identify" in `packages/integration-oauth/src/providers/discord.ts`

### Documentation
Also changed documentation to use "identify" instead of "identity"