### PR TITLE
CI: Release

### DIFF
--- a/.auri/$8x8cdzkj.md
+++ b/.auri/$8x8cdzkj.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth"
-type: "patch"
----
-
-Fix the default scope for the Discord provider

--- a/packages/integration-oauth/CHANGELOG.md
+++ b/packages/integration-oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/oauth
 
+## 0.6.3
+
+### Patch changes
+
+- [#391](https://github.com/pilcrowOnPaper/lucia/pull/391) by [@BenocxX](https://github.com/BenocxX) : Fix the default scope for the Discord provider
+
 ## 0.6.2
 
 ### Patch changes

--- a/packages/integration-oauth/package.json
+++ b/packages/integration-oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "0.6.2",
+	"version": "0.6.3",
 	"description": "OAuth integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/oauth@0.6.3
#### Patch changes

- [#391](https://github.com/pilcrowOnPaper/lucia/pull/391) by [@BenocxX](https://github.com/BenocxX) : Fix the default scope for the Discord provider