### PR TITLE
CI: Release

### DIFF
--- a/.auri/$0quvf5nb.md
+++ b/.auri/$0quvf5nb.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-- Update dependencies

--- a/.auri/$3hym1yfb.md
+++ b/.auri/$3hym1yfb.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/sveltekit" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-- Update dependencies

--- a/.auri/$3jac36wv.md
+++ b/.auri/$3jac36wv.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/nextjs" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-- Update dependencies

--- a/.auri/$3tawa3g8.md
+++ b/.auri/$3tawa3g8.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/tokens" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-[Breaking] Renamed `TokenError` to `LuciaTokenError`

--- a/.auri/$9jerp0tc.md
+++ b/.auri/$9jerp0tc.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-test" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-- Update dependencies

--- a/.auri/$gm9ujx8p.md
+++ b/.auri/$gm9ujx8p.md
@@ -1,7 +1,0 @@
----
-package: "lucia-auth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Fix issues with single use keys
-    - [Breaking] Update `createKey()`

--- a/.auri/$k2hu46gx.md
+++ b/.auri/$k2hu46gx.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/astro" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-- Update dependencies

--- a/.auri/$m47uoa8r.md
+++ b/.auri/$m47uoa8r.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/tokens" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-[Breaking] Update `idToken()` and `passwordToken()`

--- a/.auri/$p033c4d6.md
+++ b/.auri/$p033c4d6.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mongoose" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-- Update dependencies

--- a/.auri/$re2lo3hj.md
+++ b/.auri/$re2lo3hj.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-session-redis" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-- Update dependencies

--- a/.auri/$t2w4spf9.md
+++ b/.auri/$t2w4spf9.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-prisma" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-- Update dependencies

--- a/.auri/$wow7wz7y.md
+++ b/.auri/$wow7wz7y.md
@@ -1,6 +1,0 @@
----
-package: "lucia-auth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Replace `Token.isExpired()` with `Token.isExpired`

--- a/.auri/$yijrum7c.md
+++ b/.auri/$yijrum7c.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-kysely" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-- Update dependencies

--- a/documentation/collection/main/reference/api/auth.md
+++ b/documentation/collection/main/reference/api/auth.md
@@ -44,7 +44,7 @@ const createKey: (
 | keyData.providerId     | `string`                       | the provider id of the key                                      |
 | keyData.providerUserId | `string`                       | the provider user id of the key                                 |
 | keyData.password       | `string \| null`               | the password for the key                                        |
-| keyData.timeout        | `number`               | single use keys only - how long the key is valid for in seconds |
+| keyData.timeout        | `number`                       | single use keys only - how long the key is valid for in seconds |
 
 #### Returns
 

--- a/packages/adapter-kysely/CHANGELOG.md
+++ b/packages/adapter-kysely/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-kysely
 
+## 0.7.1
+
+### Patch changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
+
 ## 0.7.0
 
 ### Minor changes

--- a/packages/adapter-kysely/package.json
+++ b/packages/adapter-kysely/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-kysely",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"description": "Kysely adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/adapter-mongoose/CHANGELOG.md
+++ b/packages/adapter-mongoose/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-mongoose
 
+## 0.6.1
+
+### Patch changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
+
 ## 0.6.0
 
 ### Minor changes

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mongoose",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Mongoose (MongoDB) adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/adapter-prisma/CHANGELOG.md
+++ b/packages/adapter-prisma/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-prisma
 
+## 0.6.1
+
+### Patch changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
+
 ## 0.6.0
 
 ### Minor changes

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-prisma",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Prisma adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/adapter-session-redis/CHANGELOG.md
+++ b/packages/adapter-session-redis/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-session-redis
 
+## 0.1.6
+
+### Patch changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
+
 ## 0.1.5
 
 ### Patch changes

--- a/packages/adapter-session-redis/package.json
+++ b/packages/adapter-session-redis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-session-redis",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "Redis session adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/adapter-test/CHANGELOG.md
+++ b/packages/adapter-test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-test
 
+## 0.5.1
+
+### Patch changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
+
 ## 0.5.0
 
 ### Minor changes

--- a/packages/adapter-test/package.json
+++ b/packages/adapter-test/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-test",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "Tests for database adapters for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/integration-astro/CHANGELOG.md
+++ b/packages/integration-astro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/astro
 
+## 0.5.7
+
+### Patch changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
+
 ## 0.5.6
 
 ### Patch changes

--- a/packages/integration-astro/package.json
+++ b/packages/integration-astro/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/astro",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"description": "Lucia integration for Astro",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/integration-nextjs/CHANGELOG.md
+++ b/packages/integration-nextjs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/nextjs
 
+## 0.5.7
+
+### Patch changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
+
 ## 0.5.6
 
 ### Patch changes

--- a/packages/integration-nextjs/package.json
+++ b/packages/integration-nextjs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/nextjs",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"description": "Lucia integration for Next.js",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/integration-oauth/CHANGELOG.md
+++ b/packages/integration-oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/oauth
 
+## 0.7.2
+
+### Patch changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
+
 ## 0.7.1
 
 ### Patch changes

--- a/packages/integration-oauth/package.json
+++ b/packages/integration-oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"description": "OAuth integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/integration-sveltekit/CHANGELOG.md
+++ b/packages/integration-sveltekit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/sveltekit
 
+## 0.6.11
+
+### Patch changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
+
 ## 0.6.10
 
 ### Patch changes

--- a/packages/integration-sveltekit/package.json
+++ b/packages/integration-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/sveltekit",
-	"version": "0.6.10",
+	"version": "0.6.11",
 	"description": "SvelteKit integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/integration-tokens/CHANGELOG.md
+++ b/packages/integration-tokens/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lucia-auth/tokens
 
+## 0.2.0
+
+### Minor changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : [Breaking] Renamed `TokenError` to `LuciaTokenError`
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : [Breaking] Update `idToken()` and `passwordToken()`
+
 ## 0.1.1
 
 ### Patch changes

--- a/packages/integration-tokens/package.json
+++ b/packages/integration-tokens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/tokens",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "Tokens integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/lucia-auth/CHANGELOG.md
+++ b/packages/lucia-auth/CHANGELOG.md
@@ -1,5 +1,15 @@
 # lucia-auth
 
+## 0.10.0
+
+### Minor changes
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix issues with single use keys
+
+  - [Breaking] Update `createKey()`
+
+- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Replace `Token.isExpired()` with `Token.isExpired`
+
 ## 0.9.1
 
 ### Patch changes

--- a/packages/lucia-auth/package.json
+++ b/packages/lucia-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia-auth",
-	"version": "0.9.1",
+	"version": "0.10.0",
 	"description": "A simple and flexible authentication library",
 	"main": "index.js",
 	"types": "index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/oauth@0.7.2
#### Patch changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
### @lucia-auth/sveltekit@0.6.11
#### Patch changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
### @lucia-auth/nextjs@0.5.7
#### Patch changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
### @lucia-auth/tokens@0.2.0
#### Minor changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : [Breaking] Renamed `TokenError` to `LuciaTokenError`

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : [Breaking] Update `idToken()` and `passwordToken()`
### @lucia-auth/adapter-test@0.5.1
#### Patch changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
### lucia-auth@0.10.0
#### Minor changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix issues with single use keys
    - [Breaking] Update `createKey()`

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Replace `Token.isExpired()` with `Token.isExpired`
### @lucia-auth/astro@0.5.7
#### Patch changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
### @lucia-auth/adapter-mongoose@0.6.1
#### Patch changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
### @lucia-auth/adapter-session-redis@0.1.6
#### Patch changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
### @lucia-auth/adapter-prisma@0.6.1
#### Patch changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies
### @lucia-auth/adapter-kysely@0.7.1
#### Patch changes

- [#424](https://github.com/pilcrowOnPaper/lucia/pull/424) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : - Update dependencies