### PR TITLE
docs: add a how to use lucia prisma adapter with mongodb

### DIFF
--- a/documentation/content/main/database/prisma.md
+++ b/documentation/content/main/database/prisma.md
@@ -113,3 +113,22 @@ model AuthUser {
   @@map("user")
 }
 ```
+
+## Schema with MongoDB
+
+If you're looking to use Prisma with MongoDB the only change you need to make is on the `id` property. You need to change the `@unique` attribute to `@map("_id")`. Lucia under the hood generates a short id automatically for the 3 models (user, session, key) which means we won't use `@ObjectId`, `@default(auto())` or `@db.ObjectId` at all.
+
+So in a nutshell, replace `id String @id @unique` with `id String @id @map("_id")` in the 3 models (user, session, key) we saw above.
+
+```prisma
+id String @id @map("_id")
+```
+
+Obviously, our `datasource` will also need to change to `provider = "mongodb"`.
+
+```prisma
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+```

--- a/documentation/content/main/database/prisma.md
+++ b/documentation/content/main/database/prisma.md
@@ -118,7 +118,7 @@ model AuthUser {
 
 If you're looking to use Prisma with MongoDB the only change you need to make is on the `id` property. You need to change the `@unique` attribute to `@map("_id")`. Lucia under the hood generates a short id automatically for the 3 models (user, session, key) which means we won't use `@ObjectId`, `@default(auto())` or `@db.ObjectId` at all.
 
-So in a nutshell, replace `id String @id @unique` with `id String @id @map("_id")` in the 3 models (user, session, key) we saw above.
+So in a nutshell, replace `id String @id @unique` with `id String @id @map("_id")` in the 3 models (user, session, key) shown above.
 
 ```prisma
 id String @id @map("_id")

--- a/documentation/content/main/database/prisma.md
+++ b/documentation/content/main/database/prisma.md
@@ -124,7 +124,7 @@ So in a nutshell, replace `id String @id @unique` with `id String @id @map("_id"
 id String @id @map("_id")
 ```
 
-Obviously, our `datasource` will also need to change to `provider = "mongodb"`.
+Our `datasource` will also need to change to `provider = "mongodb"`.
 
 ```prisma
 datasource db {


### PR DESCRIPTION
This PR adds a section in the documentation that explains how to use the Lucia Prisma Adapter with MongoDB. Prisma is a popular ORM that supports various databases, including MongoDB.