### PR TITLE
Fix dark mode heading color

### DIFF
--- a/documentation/src/pages/[...content].astro
+++ b/documentation/src/pages/[...content].astro
@@ -87,7 +87,7 @@ const contributePageUrl = new URL(
 		</article>
 	</main>
 	<div class="fixed right-0 top-0 hidden h-screen w-64 pr-8 pt-24 lg:block">
-		<h2 class="mb-1 text-sm font-medium">On this page</h2>
+		<h2 class="mb-1 text-sm font-medium dark:text-zinc-200">On this page</h2>
 		<ul
 			class="relative h-full list-none overflow-auto overscroll-contain pb-8 text-sm text-zinc-500 dark:text-zinc-400"
 		>


### PR DESCRIPTION
old:
![image](https://user-images.githubusercontent.com/67872951/230799230-445eaba4-e990-4970-8077-cdd89d6d7b48.png)

new:
![image](https://user-images.githubusercontent.com/67872951/230799215-a2ee9c31-8a9a-423b-8d1a-793ed48aa608.png)

Light mode remains unchanged
