### PR TITLE
Fix "Contribute to this page" href

### DIFF
--- a/documentation/src/pages/[...content].astro
+++ b/documentation/src/pages/[...content].astro
@@ -80,7 +80,7 @@ const contributePageUrl = new URL(
 			<div class="mt-16">
 				<a
 					href={contributePageUrl.href}
-					class="text-main cursor-pointer; hover:underline"
+					class="text-main cursor-pointer hover:underline"
 					>Contribute to this page</a
 				>
 			</div>

--- a/documentation/src/pages/[...content].astro
+++ b/documentation/src/pages/[...content].astro
@@ -52,7 +52,7 @@ const frameworkId =
 
 const contributePageUrl = new URL(
 	`${content.metaData.path}.md`,
-	"https://github.com/pilcrowOnPaper/lucia/blob/main/documentation/collection"
+	`https://github.com/pilcrowOnPaper/lucia/blob/main/documentation/content/${content.metaData.collectionId ?? "main"}`
 );
 ---
 
@@ -79,7 +79,7 @@ const contributePageUrl = new URL(
 			</MarkdownContent>
 			<div class="mt-16">
 				<a
-					href={contributePageUrl}
+					href={contributePageUrl.href}
 					class="text-main cursor-pointer; hover:underline"
 					>Contribute to this page</a
 				>


### PR DESCRIPTION
Replaces the "collection" placeholder with the actual `collectionId`, and add the /content path to the URL.

I wasn't actually able to test this locally because of missing environment variables. Hopefully the Vercel preview deployment proves useful?