### PR TITLE
Import prismaClient in lucia.ts

### DIFF
--- a/documentation/content/main/start-here/getting-started.astro.md
+++ b/documentation/content/main/start-here/getting-started.astro.md
@@ -24,6 +24,7 @@ In `src/lib/lucia.ts`, import [`lucia`](/reference/lucia-auth/auth) from `lucia-
 // src/lib/lucia.ts
 import lucia from "lucia-auth";
 import prisma from "@lucia-auth/adapter-prisma";
+import { prismaClient } from "@prisma/client";
 import { astro } from "lucia-auth/middleware";
 
 export const auth = lucia({

--- a/documentation/content/main/start-here/getting-started.md
+++ b/documentation/content/main/start-here/getting-started.md
@@ -40,6 +40,7 @@ In a TypeScript file, import [`lucia`](/reference/lucia-auth/auth) and an adapte
 // lucia.ts
 import lucia from "lucia-auth";
 import prisma from "@lucia-auth/adapter-prisma";
+import { prismaClient } from "@prisma/client";
 
 export const auth = lucia({
 	adapter: prisma(prismaClient), // TODO: initialize Prisma client

--- a/documentation/content/main/start-here/getting-started.nextjs.md
+++ b/documentation/content/main/start-here/getting-started.nextjs.md
@@ -25,6 +25,7 @@ In `auth/lucia.ts`, import [`lucia`](/reference/lucia-auth/auth) from `lucia-aut
 import lucia from "lucia-auth";
 import { node } from "lucia-auth/middleware";
 import prisma from "@lucia-auth/adapter-prisma";
+import { prismaClient } from "@prisma/client";
 import { dev } from "$app/environment";
 
 export const auth = lucia({

--- a/documentation/content/main/start-here/getting-started.sveltekit.md
+++ b/documentation/content/main/start-here/getting-started.sveltekit.md
@@ -25,6 +25,7 @@ In `$lib/server/lucia.ts`, import [`lucia`](/reference/lucia-auth/auth) from `lu
 import lucia from "lucia-auth";
 import { sveltekit } from "lucia-auth/middleware";
 import prisma from "@lucia-auth/adapter-prisma";
+import { prismaClient } from "@prisma/client";
 import { dev } from "$app/environment";
 
 export const auth = lucia({


### PR DESCRIPTION
Thank you for Lucia and the stellar documentation! The prismaClient import might be missing in the SvelteKit `lucia.ts` example, unless I'm misunderstanding.