### PR TITLE
Fix documentation: Missing Sveltekit cookies interface in requestHandler definition

### DIFF
--- a/documentation/content/oauth/start-here/getting-started.sveltekit.md
+++ b/documentation/content/oauth/start-here/getting-started.sveltekit.md
@@ -43,7 +43,7 @@ import { auth, githubAuth } from "$lib/lucia.js";
 
 import type { RequestHandler } from "./$types";
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ cookies }) => {
 	// get url to redirect the user to, with the state
 	const [url, state] = await githubAuth.getAuthorizationUrl();
 


### PR DESCRIPTION
The documentation is missing the definition of the cookies method in the example, which is used to set the "github_oauth_state" in the github flow.

This PR changes:
`export const GET: RequestHandler = async () => {`

to
`export const GET: RequestHandler = async ({ cookies }) => {`