### PR TITLE
Fix documentation: Minor clean up on docs for incorrect names/urls

### DIFF
--- a/documentation/content/main/start-here/username-password.astro.md
+++ b/documentation/content/main/start-here/username-password.astro.md
@@ -71,7 +71,7 @@ Create `pages/signup.astro`. This form will have an input field for username and
 
 In the same page, we'll also handle the POST request from the form.
 
-Users and keys can be created with [`createUser()`](/reference/lucia-auth/auth#createuser). Create a new session with [`createSession()`](/reference/lucia-auth/auth?framework=sveltekit#createsession) and make sure to store the session id by calling  [`AuthRequest.setSession()`](/reference/lucia-auth/authrequest#setsession).
+Users and keys can be created with [`createUser()`](/reference/lucia-auth/auth#createuser). Create a new session with [`createSession()`](/reference/lucia-auth/auth?framework=astro#createsession) and make sure to store the session id by calling  [`AuthRequest.setSession()`](/reference/lucia-auth/authrequest#setsession).
 
 ```astro
 ---

--- a/documentation/content/main/start-here/username-password.nextjs.md
+++ b/documentation/content/main/start-here/username-password.nextjs.md
@@ -111,7 +111,7 @@ Create `pages/api/signup.ts`. This API route will handle account creation.
 
 Calling [`handleRequest()`] will create a new [`AuthRequest`](/referencel/lucia-auth/authrequest) instance, which makes it easier to handle sessions and cookies. This can be initialized with `NextApiRequest` and `NextApiResponse`.
 
-Users can be created with `createUser()`. This will create a new primary key that can be used to authenticate user as well. We’ll use `"username"` as the provider id (authentication method) and the username as the provider user id (something unique to the user). Create a new session with [`createSession()`](/reference/lucia-auth/auth?framework=sveltekit#createsession) and make sure to store the session id by calling [`setSession()`]().
+Users can be created with `createUser()`. This will create a new primary key that can be used to authenticate user as well. We’ll use `"username"` as the provider id (authentication method) and the username as the provider user id (something unique to the user). Create a new session with [`createSession()`](/reference/lucia-auth/auth?framework=nextjs#createsession) and make sure to store the session id by calling [`setSession()`]().
 
 ```ts
 // pages/api/signup.ts
@@ -152,7 +152,7 @@ Calling [`handleRequest()`] will create a new [`AuthRequest`](/referencel/lucia-
 In this case, we don't need to validate the request, but we do need it for setting the session cookie with [`AuthRequest.setSession()`](/reference/lucia-auth/authrequest#setsession).
 
 ```ts
-const authRequest = auth.handleRequest(Astro);
+const authRequest = auth.handleRequest(req, res);
 ```
 
 > (warn) Next.js does not check for [cross site request forgery (CSRF)](https://owasp.org/www-community/attacks/csrf) on API requests. While `AuthRequest.validate()` and `AuthRequest.validateUser()` will do a CSRF check and only return a user/session if it passes the check, **make sure to add CSRF protection** to routes that doesn't rely on Lucia for validation. You can check if the request is coming from the same domain as where the app is hosted by using the `Origin` header.

--- a/examples/sveltekit-email/src/lib/lucia.ts
+++ b/examples/sveltekit-email/src/lib/lucia.ts
@@ -1,13 +1,13 @@
 import lucia from 'lucia-auth';
 import prisma from '@lucia-auth/adapter-prisma';
-import { astro } from 'lucia-auth/middleware';
+import { sveltekit } from 'lucia-auth/middleware';
 import { idToken } from '@lucia-auth/tokens';
 import { prismaClient } from '$lib/db';
 
 export const auth = lucia({
 	env: import.meta.env.DEV ? 'DEV' : 'PROD',
 	adapter: prisma(prismaClient),
-	middleware: astro(),
+	middleware: sveltekit(),
 	transformDatabaseUser: (userData) => {
 		return {
 			userId: userData.id,


### PR DESCRIPTION
In a couple of places on the docs and examples, incorrect frameworks were described or imported.

Only a minor thing but always good for DX

