### PR TITLE
Fix broken link to OAuth providers integrations

### DIFF
--- a/documentation/content/reference/oauth/lucia-auth-oauth.md
+++ b/documentation/content/reference/oauth/lucia-auth-oauth.md
@@ -29,7 +29,7 @@ Refer to [`LuciaOAuthRequestError`](/reference/oauth/luciaoauthrequesterror).
 
 ## `provider`
 
-Creates a new [`OAuthProvider`](/reference/oauth/oauthprovider). If you're creating your own provider, take a look at [Lucia's repository](https://github.com/pilcrowOnPaper/lucia/tree/main/packages/integration-oauth/src/providers/index.js) for examples.
+Creates a new [`OAuthProvider`](/reference/oauth/oauthprovider). If you're creating your own provider, take a look at [Lucia's repository](https://github.com/pilcrowOnPaper/lucia/tree/main/packages/integration-oauth/src/providers) for examples.
 
 ```ts
 const provider = (


### PR DESCRIPTION
Link 404s since filename has changed from `index.js` to `index.ts`. This PR points the link to the directory listing.