### PR TITLE
[Typo] - change prismascale to planetscale

### DIFF
--- a/documentation/content/main/database/prisma.md
+++ b/documentation/content/main/database/prisma.md
@@ -133,9 +133,9 @@ datasource db {
 }
 ```
 
-## Using PrismaScale
+## Using Planetscale
 
-Since PrismaScale does not support foreign keys, change `relationMode` to `prisma` inside the schema `datasource`.
+Since Planetscale does not allow foreign keys, change `relationMode` to `prisma` inside the schema `datasource`.
 
 ```prisma
 datasource db {


### PR DESCRIPTION
Just A Simple Typo Fix, 

https://www.prisma.io/docs/guides/database/planetscale#:~:text=PlanetScale%20does%20not%20allow%20foreign%20keys