### PR TITLE
Remove Nanoid dependency

### DIFF
--- a/.auri/$6l1f7cok.md
+++ b/.auri/$6l1f7cok.md
@@ -1,0 +1,7 @@
+---
+package: "lucia-auth" # package name
+type: "minor" # "major", "minor", "patch"
+---
+
+`generateRandomString()` takes an optional second parameter - alphabet
+    - Remove `nanoid` dependency

--- a/.auri/$oyjxfoxw.md
+++ b/.auri/$oyjxfoxw.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/tokens" # package name
+type: "patch" # "major", "minor", "patch"
+---
+
+Remove `nanoid` dependency

--- a/documentation/content/main/basics/users.md
+++ b/documentation/content/main/basics/users.md
@@ -174,7 +174,7 @@ const user = auth.deleteUser(userId);
 
 You can generate your own user ids by setting [`generateCustomUserId()`](/basics/configuration#generatecustomuserid), which can either be synchronous or asynchronous.
 
-If you need to generate a cryptographically random alphanumeric string, Lucia provides [`generateRandomString()`](/reference/lucia-auth/lucia-auth#generaterandomstring). This function uses the [`nanoid`](https://github.com/ai/nanoid) package.
+If you need to generate a cryptographically random alphanumeric string, Lucia provides [`generateRandomString()`](/reference/lucia-auth/lucia-auth#generaterandomstring). This function is based on the [`nanoid`](https://github.com/ai/nanoid) package.
 
 ```ts
 import { generateCustomUserId } from "lucia-auth";

--- a/documentation/content/reference/lucia-auth/lucia-auth.md
+++ b/documentation/content/reference/lucia-auth/lucia-auth.md
@@ -13,10 +13,10 @@ For exported types, refer to [Public types](/reference/lucia-auth/types).
 
 ## `generateRandomString()`
 
-Generates a random string of a defined length using [`nanoid`](https://github.com/ai/nanoid) without special characters. The output is cryptographically random.
+Generates a random string of a defined length without special characters based on [`nanoid`](https://github.com/ai/nanoid). The output is cryptographically random.
 
 ```ts
-const generateRandomString: (length: number) => string;
+const generateRandomString: (length: number, alphabet?: string) => string;
 ```
 
 Uses the following characters (uppercase, lowercase, numbers):
@@ -27,9 +27,10 @@ Uses the following characters (uppercase, lowercase, numbers):
 
 #### Parameter
 
-| name   | type     | description                     |
-| ------ | -------- | ------------------------------- |
-| length | `number` | the length of the output string |
+| name     | type     | description                                   | optional |
+| -------- | -------- | --------------------------------------------- | -------- |
+| length   | `number` | the length of the output string               |          |
+| alphabet | `string` | a string from which to pick random characters | true     |
 
 #### Returns
 
@@ -40,7 +41,8 @@ Uses the following characters (uppercase, lowercase, numbers):
 #### Example
 
 ```ts
-const randomString = generateRandomString(8);
+// 8 char password consisting of 0-9 
+const randomPassword = generateRandomString(8, "0123456789");
 ```
 
 #### Example

--- a/examples/astro-email/package.json
+++ b/examples/astro-email/package.json
@@ -17,7 +17,6 @@
 		"@prisma/client": "^4.12.0",
 		"astro": "^2.1.3",
 		"lucia-auth": "workspace:*",
-		"nanoid": "^4.0.0",
 		"tailwindcss": "^3.0.24"
 	},
 	"devDependencies": {

--- a/examples/astro-email/src/auth/email.ts
+++ b/examples/astro-email/src/auth/email.ts
@@ -1,5 +1,5 @@
 import { prismaClient } from "src/db";
-import { customAlphabet } from "nanoid";
+import { generateRandomString } from "lucia-auth";
 import type { Email as DatabaseEmail } from "@prisma/client";
 
 const sendEmail = async (
@@ -7,12 +7,9 @@ const sendEmail = async (
 	subject: string,
 	content: string
 ) => {
-	const generateId = customAlphabet(
-		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	);
 	await prismaClient.email.create({
 		data: {
-			id: generateId(8),
+			id: generateRandomString(8),
 			subject,
 			email_address: emailAddress,
 			content,

--- a/examples/sveltekit-email/package.json
+++ b/examples/sveltekit-email/package.json
@@ -36,7 +36,6 @@
 		"@lucia-auth/adapter-prisma": "^1.0.0",
 		"@lucia-auth/tokens": "^1.0.0",
 		"@prisma/client": "^4.12.0",
-		"lucia-auth": "^1.0.0",
-		"nanoid": "^4.0.0"
+		"lucia-auth": "^1.0.0"
 	}
 }

--- a/examples/sveltekit-email/src/lib/email.ts
+++ b/examples/sveltekit-email/src/lib/email.ts
@@ -1,14 +1,11 @@
 import { prismaClient } from '$lib/db';
-import { customAlphabet } from 'nanoid';
 import type { Email as DatabaseEmail } from '@prisma/client';
+import { generateRandomString } from 'lucia-auth';
 
 const sendEmail = async (emailAddress: string, subject: string, content: string) => {
-	const generateId = customAlphabet(
-		'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
-	);
 	await prismaClient.email.create({
 		data: {
-			id: generateId(8),
+			id: generateRandomString(8),
 			subject,
 			email_address: emailAddress,
 			content,

--- a/packages/integration-tokens/package.json
+++ b/packages/integration-tokens/package.json
@@ -33,8 +33,7 @@
 	"author": "pilcrowonpaper",
 	"license": "MIT",
 	"dependencies": {
-		"lucia-auth": "workspace:*",
-		"nanoid": "^4.0.0"
+		"lucia-auth": "workspace:*"
 	},
 	"peerDependencies": {
 		"lucia-auth": "1.x"

--- a/packages/integration-tokens/src/index.ts
+++ b/packages/integration-tokens/src/index.ts
@@ -1,22 +1,2 @@
-import type { SingleUseKey } from "lucia-auth";
-
-export { idToken, passwordToken } from "./tokens.js";
+export { idToken, passwordToken, Token } from "./tokens.js";
 export { LuciaTokenError } from "./error.js";
-
-export class Token {
-	private readonly value: string;
-
-	public readonly toString = () => this.value;
-	public readonly expiresAt: Date;
-	public readonly expired: boolean;
-	public readonly userId: string;
-	public readonly key: Readonly<SingleUseKey>;
-
-	constructor(value: string, key: SingleUseKey) {
-		this.value = value;
-		this.expiresAt = key.expiresAt;
-		this.expired = key.expired;
-		this.userId = key.userId;
-		this.key = key;
-	}
-}

--- a/packages/integration-tokens/src/tokens.ts
+++ b/packages/integration-tokens/src/tokens.ts
@@ -1,9 +1,26 @@
-import { customAlphabet } from "nanoid";
-import { Token } from "./index.js";
-import { type LuciaError, generateRandomString } from "lucia-auth";
-
-import type { Auth, SingleUseKey } from "lucia-auth";
 import { LuciaTokenError } from "./error.js";
+import { generateRandomString } from "./utils/nanoid.js";
+
+import type { Auth, SingleUseKey, LuciaError } from "lucia-auth";
+
+export class Token {
+	private readonly value: string;
+
+	public readonly toString = () => this.value;
+	public readonly expiresAt: Date;
+	public readonly expired: boolean;
+	public readonly userId: string;
+	public readonly key: Readonly<SingleUseKey>;
+
+	constructor(value: string, key: SingleUseKey) {
+		this.value = value;
+		this.expiresAt = key.expiresAt;
+		this.expired = key.expired;
+		this.userId = key.userId;
+		this.key = key;
+	}
+}
+
 
 type TokenWrapper = Readonly<{
 	issue: (...args: any) => Promise<Token>;
@@ -99,10 +116,12 @@ export const passwordToken = (
 		generate?: (length?: number) => string;
 	}
 ) => {
-	const generateRandomNumberString = customAlphabet("0123456789", 8);
+	const defaultGenerateRandomPassword = (length: number) => {
+		return generateRandomString(length, "0123456789");
+	};
 	return {
 		issue: async (userId: string) => {
-			const generate = options.generate ?? generateRandomNumberString;
+			const generate = options.generate ?? defaultGenerateRandomPassword;
 			const token = generate(options.length ?? 8);
 			const providerUserId = [userId, token].join(".");
 			try {

--- a/packages/integration-tokens/src/utils/nanoid.ts
+++ b/packages/integration-tokens/src/utils/nanoid.ts
@@ -1,0 +1,33 @@
+// code copied from Nanoid:
+// https://github.com/ai/nanoid/blob/9b748729f8ad5409503b508b65958636e55bd87a/index.browser.js
+// nanoid uses Node dependencies on default bundler settings
+
+// TODO: on next major update, use generateRandomString imported from lucia-auth
+
+const getRandomValues = (bytes: number) =>
+	crypto.getRandomValues(new Uint8Array(bytes));
+
+const DEFAULT_ALPHABET =
+	"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+
+export const generateRandomString = (
+	size: number,
+	alphabet = DEFAULT_ALPHABET
+) => {
+	const mask = (2 << (Math.log(alphabet.length - 1) / Math.LN2)) - 1;
+	const step = -~((1.6 * mask * size) / alphabet.length);
+
+	let bytes = getRandomValues(step);
+	let id = "";
+	let index = 0;
+
+	while (id.length !== size) {
+		id += alphabet[bytes[index] & mask] ?? "";
+		index += 1;
+		if (index > bytes.length) {
+			bytes = getRandomValues(step);
+			index = 0;
+		}
+	}
+	return id;
+};

--- a/packages/lucia-auth/package.json
+++ b/packages/lucia-auth/package.json
@@ -46,7 +46,6 @@
 		"prettier": "^2.3.0"
 	},
 	"dependencies": {
-		"@noble/hashes": "^1.1.3",
-		"nanoid": "^4.0.0"
+		"@noble/hashes": "^1.1.3"
 	}
 }

--- a/packages/lucia-auth/src/auth/index.ts
+++ b/packages/lucia-auth/src/auth/index.ts
@@ -5,11 +5,8 @@ import {
 	createSessionCookie
 } from "./cookie.js";
 import { logError } from "../utils/log.js";
-import {
-	generateHashWithScrypt,
-	generateRandomString,
-	validateScryptHash
-} from "../utils/crypto.js";
+import { generateHashWithScrypt, validateScryptHash } from "../utils/crypto.js";
+import { generateRandomString } from "../utils/nanoid.js";
 import { LuciaError } from "./error.js";
 import { parseCookie } from "../utils/cookie.js";
 import { validateDatabaseSession } from "./session.js";

--- a/packages/lucia-auth/src/index.ts
+++ b/packages/lucia-auth/src/index.ts
@@ -1,7 +1,7 @@
 export { lucia as default } from "./auth/index.js";
 export { SESSION_COOKIE_NAME, Cookie } from "./auth/cookie.js";
 export { LuciaError, LuciaErrorConstructor } from "./auth/error.js";
-export { generateRandomString } from "./utils/crypto.js";
+export { generateRandomString } from "./utils/nanoid.js";
 export { serializeCookie } from "./utils/cookie.js";
 
 export type GlobalAuth = Lucia.Auth;

--- a/packages/lucia-auth/src/utils/crypto.ts
+++ b/packages/lucia-auth/src/utils/crypto.ts
@@ -1,11 +1,5 @@
-import { random, customRandom } from "nanoid";
 import { scryptAsync } from "@noble/hashes/scrypt";
-
-export const generateRandomString = (length: number) => {
-	const characters =
-		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
-	return customRandom(characters, length, random)();
-};
+import { generateRandomString } from "./nanoid.js";
 
 export const generateHashWithScrypt = async (s: string) => {
 	const salt = generateRandomString(16);

--- a/packages/lucia-auth/src/utils/nanoid.ts
+++ b/packages/lucia-auth/src/utils/nanoid.ts
@@ -1,0 +1,31 @@
+// code copied from Nanoid:
+// https://github.com/ai/nanoid/blob/9b748729f8ad5409503b508b65958636e55bd87a/index.browser.js
+// nanoid uses Node dependencies on default bundler settings
+
+const getRandomValues = (bytes: number) =>
+	crypto.getRandomValues(new Uint8Array(bytes));
+
+const DEFAULT_ALPHABET =
+	"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+
+export const generateRandomString = (
+	size: number,
+	alphabet = DEFAULT_ALPHABET
+) => {
+	const mask = (2 << (Math.log(alphabet.length - 1) / Math.LN2)) - 1;
+	const step = -~((1.6 * mask * size) / alphabet.length);
+
+	let bytes = getRandomValues(step);
+	let id = "";
+	let index = 0;
+
+	while (id.length !== size) {
+		id += alphabet[bytes[index] & mask] ?? "";
+		index += 1;
+		if (index > bytes.length) {
+			bytes = getRandomValues(step);
+			index = 0;
+		}
+	}
+	return id;
+};

--- a/test-apps/astro-email/package.json
+++ b/test-apps/astro-email/package.json
@@ -17,7 +17,6 @@
 		"@prisma/client": "^4.12.0",
 		"astro": "^2.1.3",
 		"lucia-auth": "workspace:*",
-		"nanoid": "^4.0.0",
 		"tailwindcss": "^3.0.24"
 	},
 	"devDependencies": {

--- a/test-apps/astro-email/src/auth/email.ts
+++ b/test-apps/astro-email/src/auth/email.ts
@@ -1,5 +1,5 @@
 import { prismaClient } from "src/db";
-import { customAlphabet } from "nanoid";
+import { generateRandomString } from 'lucia-auth';
 import type { Email as DatabaseEmail } from "@prisma/client";
 
 const sendEmail = async (
@@ -7,12 +7,9 @@ const sendEmail = async (
 	subject: string,
 	content: string
 ) => {
-	const generateId = customAlphabet(
-		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	);
 	await prismaClient.email.create({
 		data: {
-			id: generateId(8),
+			id: generateRandomString(8),
 			subject,
 			email_address: emailAddress,
 			content,

--- a/test-apps/sveltekit-email/package.json
+++ b/test-apps/sveltekit-email/package.json
@@ -36,7 +36,6 @@
 		"@lucia-auth/adapter-prisma": "workspace:*",
 		"@lucia-auth/tokens": "workspace:*",
 		"@prisma/client": "^4.12.0",
-		"lucia-auth": "workspace:*",
-		"nanoid": "^4.0.0"
+		"lucia-auth": "workspace:*"
 	}
 }

--- a/test-apps/sveltekit-email/src/lib/email.ts
+++ b/test-apps/sveltekit-email/src/lib/email.ts
@@ -1,14 +1,11 @@
 import { prismaClient } from '$lib/db';
-import { customAlphabet } from 'nanoid';
+import { generateRandomString } from 'lucia-auth';
 import type { Email as DatabaseEmail } from '@prisma/client';
 
 const sendEmail = async (emailAddress: string, subject: string, content: string) => {
-	const generateId = customAlphabet(
-		'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
-	);
 	await prismaClient.email.create({
 		data: {
-			id: generateId(8),
+			id: generateRandomString(8),
 			subject,
 			email_address: emailAddress,
 			content,


### PR DESCRIPTION
Nanoid depends on `node` native modules, and while it's possible to switch to the provided browser version, it requires some tweaking on the bundler side.