### PR TITLE
Fix: Remove unused async from `getAuthorizatinoUrl` and other minor fixes

### DIFF
--- a/documentation/content/oauth/start-here/getting-started.md
+++ b/documentation/content/oauth/start-here/getting-started.md
@@ -45,7 +45,7 @@ const handleGetRequests = async () => {
 	const providerAuth = provider(auth, config);
 
 	// get url to redirect the user to, with the state
-	const [url, state] = await githubAuth.getAuthorizationUrl();
+	const [url, state] = githubAuth.getAuthorizationUrl();
 
 	// the state can be stored in cookies or localstorage for request validation on callback
 	setCookie("github_oauth_state", state, {

--- a/documentation/content/oauth/start-here/getting-started.sveltekit.md
+++ b/documentation/content/oauth/start-here/getting-started.sveltekit.md
@@ -45,7 +45,7 @@ import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ cookies }) => {
 	// get url to redirect the user to, with the state
-	const [url, state] = await githubAuth.getAuthorizationUrl();
+	const [url, state] = githubAuth.getAuthorizationUrl();
 
 	// the state can be stored in cookies or localstorage for request validation on callback
 	cookies.set("github_oauth_state", state, {

--- a/documentation/content/reference/oauth/lucia-auth-oauth.md
+++ b/documentation/content/reference/oauth/lucia-auth-oauth.md
@@ -36,7 +36,7 @@ const provider = (
 	auth: Auth,
 	config: {
 		providerId: string;
-		getAuthorizationUrl: (state: string) => Promise<URL>;
+		getAuthorizationUrl: (state: string) => URL;
 		getTokens: (code: string) => Promise<{
 			accessToken: string;
 		}>;
@@ -68,7 +68,7 @@ const provider = (
 Generates an authorization url using the provided state.
 
 ```ts
-const getAuthorizationUrl: (state: string) => Promise<URL>;
+const getAuthorizationUrl: (state: string) => URL;
 ```
 
 #### `Parameter`
@@ -88,7 +88,7 @@ const getAuthorizationUrl: (state: string) => Promise<URL>;
 Validates the provided callback code and retrieves an access token. Can return any object but must include `accessToken`.
 
 ```ts
-const getAuthorizationUrl: (code: string) => Promise<{
+const getTokens: (code: string) => Promise<{
 	accessToken: string;
 }>;
 ```
@@ -111,7 +111,7 @@ Retrieves the current user from the provider using the provided provider access 
 
 ```ts
 const getProviderUser: (accessToken: string) => Promise<[
-    providerUserId: string,
+  providerUserId: string,
 	providerUser: Record<string, any>;
 ]>;
 ```

--- a/documentation/content/reference/oauth/oauthprovider.md
+++ b/documentation/content/reference/oauth/oauthprovider.md
@@ -5,7 +5,7 @@ _order: 1
 
 ```ts
 type OAuthProvider<ProviderUser, ProviderTokens> = {
-	getAuthorizationUrl: () => Promise<[url: URL, state: string]>;
+	getAuthorizationUrl: () => [url: URL, state: string];
 	validateCallback: (
 		code: string
 	) => Promise<ProviderSession<ProviderUser, ProviderTokens>>;
@@ -17,7 +17,7 @@ type OAuthProvider<ProviderUser, ProviderTokens> = {
 Returns the authorization url for user redirection and a state for storage. This should generate and use a state using [`generateState()`](/reference/oauth/lucia-auth-oauth#generatestate).
 
 ```ts
-const getAuthorizationUrl: () => Promise<[url: URL, state: string]>;
+const getAuthorizationUrl: () => [url: URL, state: string];
 ```
 
 #### Parameter

--- a/examples/astro/src/pages/api/oauth/index.ts
+++ b/examples/astro/src/pages/api/oauth/index.ts
@@ -4,7 +4,7 @@ import type { APIRoute } from "astro";
 export const get: APIRoute = async ({ url, cookies }) => {
 	const provider = url.searchParams.get("provider");
 	if (provider === "github") {
-		const [url, state] = await githubAuth.getAuthorizationUrl();
+		const [url, state] = githubAuth.getAuthorizationUrl();
 		cookies.set("oauth_state", state, {
 			path: "/",
 			maxAge: 60 * 60

--- a/examples/nextjs/pages/api/oauth/index.ts
+++ b/examples/nextjs/pages/api/oauth/index.ts
@@ -12,7 +12,7 @@ export default async (req: NextApiRequest, res: NextApiResponse<Data>) => {
 	if (!req.url) return res.status(400);
 	const provider = req.query.provider;
 	if (provider === "github") {
-		const [url, state] = await githubAuth.getAuthorizationUrl();
+		const [url, state] = githubAuth.getAuthorizationUrl();
 		const oauthStateCookie = cookie.serialize("oauth_state", state, {
 			path: "/",
 			maxAge: 60 * 60,

--- a/examples/sveltekit/src/routes/api/oauth/+server.ts
+++ b/examples/sveltekit/src/routes/api/oauth/+server.ts
@@ -4,7 +4,7 @@ import { githubAuth } from '$lib/server/lucia';
 export const GET: RequestHandler = async ({ url, cookies }) => {
 	const provider = url.searchParams.get('provider');
 	if (provider === 'github') {
-		const [url, state] = await githubAuth.getAuthorizationUrl();
+		const [url, state] = githubAuth.getAuthorizationUrl();
 		cookies.set('oauth_state', state, {
 			path: '/',
 			maxAge: 60 * 60

--- a/packages/integration-oauth/src/core.ts
+++ b/packages/integration-oauth/src/core.ts
@@ -3,12 +3,12 @@ import { generateRandomString } from "lucia-auth";
 import type { Auth, Key, LuciaError } from "lucia-auth";
 import type { CreateUserAttributesParameter, LuciaUser } from "./lucia.js";
 
-type TokensBase = {
+export type BaseToken = {
 	accessToken: string;
 };
 
 export type OAuthProviderConfig<
-	Tokens extends TokensBase,
+	Tokens extends BaseToken,
 	ProviderUser extends Record<string, any>
 > = {
 	providerId: string;
@@ -22,7 +22,7 @@ export type OAuthProviderConfig<
 export const provider = <
 	A extends Auth,
 	ProviderUser extends Record<string, any>,
-	Tokens extends TokensBase
+	Tokens extends BaseToken
 >(
 	auth: A,
 	config: OAuthProviderConfig<Tokens, ProviderUser>

--- a/packages/integration-oauth/src/index.ts
+++ b/packages/integration-oauth/src/index.ts
@@ -1,3 +1,8 @@
 export { provider, generateState, LuciaOAuthRequestError } from "./core.js";
 
-export type { OAuthProvider } from "./core.js";
+export type {
+	OAuthProvider,
+	OAuthProviderConfig,
+	OAuthConfig,
+	BaseToken
+} from "./core.js";

--- a/packages/integration-oauth/src/providers/auth0.ts
+++ b/packages/integration-oauth/src/providers/auth0.ts
@@ -16,7 +16,7 @@ type Config = OAuthConfig & {
 };
 
 export const auth0 = (auth: Auth, config: Config) => {
-	const getAuthorizationUrl = async (state: string) => {
+	const getAuthorizationUrl = (state: string) => {
 		const url = createUrl(new URL("/authorize", config.appDomain).toString(), {
 			client_id: config.clientId,
 			response_type: "code",

--- a/packages/integration-oauth/src/providers/discord.ts
+++ b/packages/integration-oauth/src/providers/discord.ts
@@ -11,15 +11,14 @@ type Config = OAuthConfig & {
 const PROVIDER_ID = "discord";
 
 export const discord = (auth: Auth, config: Config) => {
-	const getAuthorizationUrl = async (state: string) => {
-		const url = createUrl("https://discord.com/oauth2/authorize", {
+	const getAuthorizationUrl = (state: string) => {
+		return createUrl("https://discord.com/oauth2/authorize", {
 			response_type: "code",
 			client_id: config.clientId,
 			scope: scope(["identify"], config.scope),
 			redirect_uri: config.redirectUri,
 			state
 		});
-		return url;
 	};
 
 	const getTokens = async (code: string) => {

--- a/packages/integration-oauth/src/providers/facebook.ts
+++ b/packages/integration-oauth/src/providers/facebook.ts
@@ -11,14 +11,13 @@ type Config = OAuthConfig & {
 const PROVIDER_ID = "facebook";
 
 export const facebook = (auth: Auth, config: Config) => {
-	const getAuthorizationUrl = async (state: string) => {
-		const url = createUrl("https://www.facebook.com/v16.0/dialog/oauth", {
+	const getAuthorizationUrl = (state: string) => {
+		return createUrl("https://www.facebook.com/v16.0/dialog/oauth", {
 			client_id: config.clientId,
 			scope: scope([], config.scope),
 			redirect_uri: config.redirectUri,
 			state
 		});
-		return url;
 	};
 
 	const getTokens = async (code: string) => {

--- a/packages/integration-oauth/src/providers/github.ts
+++ b/packages/integration-oauth/src/providers/github.ts
@@ -7,13 +7,12 @@ import type { OAuthConfig } from "../core.js";
 const PROVIDER_ID = "github";
 
 export const github = (auth: Auth, config: OAuthConfig) => {
-	const getAuthorizationUrl = async (state: string) => {
-		const url = createUrl("https://github.com/login/oauth/authorize", {
+	const getAuthorizationUrl = (state: string) => {
+		return createUrl("https://github.com/login/oauth/authorize", {
 			client_id: config.clientId,
 			scope: scope([], config.scope),
 			state
 		});
-		return url;
 	};
 
 	const getTokens = async (

--- a/packages/integration-oauth/src/providers/google.ts
+++ b/packages/integration-oauth/src/providers/google.ts
@@ -11,8 +11,8 @@ type Config = OAuthConfig & {
 const PROVIDER_ID = "google";
 
 export const google = <A extends Auth>(auth: A, config: Config) => {
-	const getAuthorizationUrl = async (state: string) => {
-		const url = createUrl("https://accounts.google.com/o/oauth2/v2/auth", {
+	const getAuthorizationUrl = (state: string) => {
+		return createUrl("https://accounts.google.com/o/oauth2/v2/auth", {
 			client_id: config.clientId,
 			redirect_uri: config.redirectUri,
 			scope: scope(
@@ -22,7 +22,6 @@ export const google = <A extends Auth>(auth: A, config: Config) => {
 			response_type: "code",
 			state
 		});
-		return url;
 	};
 
 	const getTokens = async (code: string) => {

--- a/packages/integration-oauth/src/providers/linkedin.ts
+++ b/packages/integration-oauth/src/providers/linkedin.ts
@@ -11,15 +11,14 @@ type Config = OAuthConfig & {
 };
 
 export const linkedin = (auth: Auth, config: Config) => {
-	const getAuthorizationUrl = async (state: string) => {
-		const url = createUrl("https://www.linkedin.com/oauth/v2/authorization", {
+	const getAuthorizationUrl = (state: string) => {
+		return createUrl("https://www.linkedin.com/oauth/v2/authorization", {
 			client_id: config.clientId,
 			response_type: "code",
 			redirect_uri: config.redirectUri,
 			scope: scope(["r_liteprofile"], config.scope),
 			state
 		});
-		return url;
 	};
 
 	const getTokens = async (code: string) => {

--- a/packages/integration-oauth/src/providers/patreon.ts
+++ b/packages/integration-oauth/src/providers/patreon.ts
@@ -12,16 +12,14 @@ type Config = OAuthConfig & {
 const PROVIDER_ID = "patreon";
 
 export const patreon = <A extends Auth>(auth: A, config: Config) => {
-	const getAuthorizationUrl = async (state: string) => {
-		const url = createUrl("https://www.patreon.com/oauth2/authorize", {
+	const getAuthorizationUrl = (state: string) => {
+		return createUrl("https://www.patreon.com/oauth2/authorize", {
 			client_id: config.clientId,
 			redirect_uri: config.redirectUri,
 			scope: scope(["identity"], config.scope),
 			response_type: "code",
 			state
 		});
-
-		return url;
 	};
 
 	const getTokens = async (code: string) => {

--- a/packages/integration-oauth/src/providers/reddit.ts
+++ b/packages/integration-oauth/src/providers/reddit.ts
@@ -11,8 +11,8 @@ type Config = OAuthConfig & {
 const PROVIDER_ID = "reddit";
 
 export const reddit = <A extends Auth>(auth: A, config: Config) => {
-	const getAuthorizationUrl = async (state: string) => {
-		const url = createUrl("https://www.reddit.com/api/v1/authorize", {
+	const getAuthorizationUrl = (state: string) => {
+		return createUrl("https://www.reddit.com/api/v1/authorize", {
 			client_id: config.clientId,
 			response_type: "code",
 			redirect_uri: config.redirectUri,
@@ -20,8 +20,6 @@ export const reddit = <A extends Auth>(auth: A, config: Config) => {
 			scope: scope([], config.scope),
 			state
 		});
-
-		return url;
 	};
 
 	const getTokens = async (code: string) => {

--- a/packages/integration-oauth/src/providers/twitch.ts
+++ b/packages/integration-oauth/src/providers/twitch.ts
@@ -12,9 +12,10 @@ type Config = OAuthConfig & {
 const PROVIDER_ID = "twitch";
 
 export const twitch = <A extends Auth>(auth: A, config: Config) => {
-	const getAuthorizationUrl = async (state: string) => {
+	const getAuthorizationUrl = (state: string) => {
 		const forceVerify = config.forceVerify ?? false;
-		const url = createUrl("https://id.twitch.tv/oauth2/authorize", {
+
+		return createUrl("https://id.twitch.tv/oauth2/authorize", {
 			client_id: config.clientId,
 			redirect_uri: config.redirectUri,
 			scope: scope([], config.scope),
@@ -22,8 +23,6 @@ export const twitch = <A extends Auth>(auth: A, config: Config) => {
 			force_verify: forceVerify.toString(),
 			state
 		});
-
-		return url;
 	};
 
 	const getTokens = async (code: string) => {

--- a/packages/integration-oauth/src/request.ts
+++ b/packages/integration-oauth/src/request.ts
@@ -33,16 +33,16 @@ export const authorizationHeaders = (
 	type: "bearer" | "basic",
 	token: string
 ) => {
-	const getHeadersValue = () => {
-		if (type === "basic") {
-			return ["Basic", token].join(" ");
-		}
-		if (type === "bearer") {
-			return ["Bearer", token].join(" ");
-		}
-		throw new TypeError("Invalid token type");
-	};
-	return {
-		Authorization: getHeadersValue()
-	};
+	if (type === "basic") {
+		return {
+			Authorization: "Basic " + token
+		};
+	}
+	if (type === "bearer") {
+		return {
+			Authorization: "Bearer " + token
+		};
+	}
+
+	throw new TypeError("Invalid token type");
 };

--- a/test-apps/astro/src/pages/api/oauth/index.ts
+++ b/test-apps/astro/src/pages/api/oauth/index.ts
@@ -4,7 +4,7 @@ import type { APIRoute } from "astro";
 export const get: APIRoute = async ({ url, cookies }) => {
 	const provider = url.searchParams.get("provider");
 	if (provider === "github") {
-		const [url, state] = await githubAuth.getAuthorizationUrl();
+		const [url, state] = githubAuth.getAuthorizationUrl();
 		cookies.set("oauth_state", state, {
 			path: "/",
 			maxAge: 60 * 60

--- a/test-apps/nextjs/pages/api/oauth/index.ts
+++ b/test-apps/nextjs/pages/api/oauth/index.ts
@@ -12,7 +12,7 @@ export default async (req: NextApiRequest, res: NextApiResponse<Data>) => {
 	if (!req.url) return res.status(400);
 	const provider = req.query.provider;
 	if (provider === "github") {
-		const [url, state] = await githubAuth.getAuthorizationUrl();
+		const [url, state] = githubAuth.getAuthorizationUrl();
 		const oauthStateCookie = cookie.serialize("oauth_state", state, {
 			path: "/",
 			maxAge: 60 * 60,

--- a/test-apps/sveltekit/src/routes/api/oauth/+server.ts
+++ b/test-apps/sveltekit/src/routes/api/oauth/+server.ts
@@ -4,7 +4,7 @@ import { githubAuth } from '$lib/server/lucia';
 export const GET: RequestHandler = async ({ url, cookies }) => {
 	const provider = url.searchParams.get('provider');
 	if (provider === 'github') {
-		const [url, state] = await githubAuth.getAuthorizationUrl();
+		const [url, state] = githubAuth.getAuthorizationUrl();
 		cookies.set('oauth_state', state, {
 			path: '/',
 			maxAge: 60 * 60


### PR DESCRIPTION
1. `getAuthorizationUrl()` should not return a promise because there are no asynchronous operations under the hood, it only structures the URL object.

2. I extracted the types from the generics in `provider()` and exported them to the user. This may be useful for some people who want to create their own provider.

3. I removed the unnecessary nested function `getHeadersValue()`, which doesn't really make sense.

If I have forgotten or misunderstood something, let me know. 🤍