### PR TITLE
Add next button to documentation

### DIFF
--- a/documentation/integrations/cela/content.ts
+++ b/documentation/integrations/cela/content.ts
@@ -86,27 +86,31 @@ export const getNextPage = async (
 	collectionId: string,
 	frameworkId: string | null,
 	currentPage: string
-) => {
-	let nextPageInfo = null;
-
+  ) => {
 	const collection = await getCollection(collectionId, frameworkId);
-
-	if (collection) {
-		const sectionsCount = collection.sections.length - 1;
-		collection?.sections.forEach((section, secIdx) => {
-			let docsCount = section.documents.length - 1;
-			section.documents.map((document, docIdx) => {
-				if (document.pathname == currentPage) {
-					if (docIdx === docsCount) {
-						if (sectionsCount !== secIdx) {
-							nextPageInfo = collection?.sections[secIdx + 1].documents[0];
-						}
-					} else {
-						nextPageInfo = collection?.sections[secIdx].documents[docIdx + 1];
-					}
-				}
-			});
-		});
+  
+	if (!collection) {
+	  return null;
 	}
-	return nextPageInfo;
+  
+	const sectionsCount = collection.sections.length - 1;
+  
+	for (let secIdx = 0; secIdx <= sectionsCount; secIdx++) {
+	  const section = collection.sections[secIdx];
+	  const docsCount = section.documents.length - 1;
+  
+	  for (let docIdx = 0; docIdx <= docsCount; docIdx++) {
+		const document = section.documents[docIdx];
+  
+		if (document.pathname === currentPage) {
+		  if (docIdx === docsCount && secIdx !== sectionsCount) {
+			return collection.sections[secIdx + 1]?.documents[0] ?? null;
+		  } else {
+			return collection.sections[secIdx]?.documents[docIdx + 1] ?? null;
+		  }
+		}
+	  }
+	}
+  
+	return null;
 };

--- a/documentation/integrations/cela/content.ts
+++ b/documentation/integrations/cela/content.ts
@@ -91,14 +91,14 @@ export const getNextPage = async (
 
 	const collection = await getCollection(collectionId, frameworkId);
 
-	if(collection) {
+	if (collection) {
 		const sectionsCount = collection.sections.length - 1;
 		collection?.sections.forEach((section, secIdx) => {
 			let docsCount = section.documents.length - 1;
 			section.documents.map((document, docIdx) => {
-				if(document.pathname == currentPage) {
-					if(docIdx === docsCount) {
-						if(sectionsCount !== secIdx) {
+				if (document.pathname == currentPage) {
+					if (docIdx === docsCount) {
+						if (sectionsCount !== secIdx) {
 							nextPageInfo = collection?.sections[secIdx + 1].documents[0];
 						}
 					} else {
@@ -106,7 +106,7 @@ export const getNextPage = async (
 					}
 				}
 			});
-		})
+		});
 	}
 	return nextPageInfo;
-}
+};

--- a/documentation/integrations/cela/content.ts
+++ b/documentation/integrations/cela/content.ts
@@ -96,7 +96,7 @@ export const getNextPage = async (
 		collection?.sections.forEach((section, secIdx) => {
 			let docsCount = section.documents.length - 1;
 			section.documents.map((document, docIdx) => {
-				if(document.href == currentPage) {
+				if(document.pathname == currentPage) {
 					if(docIdx === docsCount) {
 						if(sectionsCount !== secIdx) {
 							nextPageInfo = collection?.sections[secIdx + 1].documents[0];

--- a/documentation/integrations/cela/content.ts
+++ b/documentation/integrations/cela/content.ts
@@ -81,3 +81,32 @@ export const getCollection = async (
 	if (!collectionFile) return null;
 	return collectionFile.default;
 };
+
+export const getNextPage = async (
+	collectionId: string,
+	frameworkId: string | null,
+	currentPage: string
+) => {
+	let nextPageInfo = null;
+
+	const collection = await getCollection(collectionId, frameworkId);
+
+	if(collection) {
+		const sectionsCount = collection.sections.length - 1;
+		collection?.sections.forEach((section, secIdx) => {
+			let docsCount = section.documents.length - 1;
+			section.documents.map((document, docIdx) => {
+				if(document.href == currentPage) {
+					if(docIdx === docsCount) {
+						if(sectionsCount !== secIdx) {
+							nextPageInfo = collection?.sections[secIdx + 1].documents[0];
+						}
+					} else {
+						nextPageInfo = collection?.sections[secIdx].documents[docIdx + 1];
+					}
+				}
+			});
+		})
+	}
+	return nextPageInfo;
+}

--- a/documentation/src/pages/[...content].astro
+++ b/documentation/src/pages/[...content].astro
@@ -60,11 +60,10 @@ const contributePageHref = joinUrlPaths(
 	content.mappedContentPath
 );
 
-let collectionId = Astro.props.collectionId ?? "main";
+const collectionId = Astro.props.collectionId ?? "main";
 const currentPathname = Astro.url.pathname;
 
 const nextPage = await getNextPage(collectionId, frameworkId, currentPathname);
-console.log(nextPage);
 ---
 
 <Layout

--- a/documentation/src/pages/[...content].astro
+++ b/documentation/src/pages/[...content].astro
@@ -64,6 +64,7 @@ let collectionId = Astro.props.collectionId ?? "main";
 const currentPathname = Astro.url.pathname;
 
 const nextPage = await getNextPage(collectionId, frameworkId, currentPathname);
+console.log(nextPage);
 ---
 
 <Layout
@@ -103,9 +104,9 @@ const nextPage = await getNextPage(collectionId, frameworkId, currentPathname);
 			{nextPage && <div class="mt-8 text-right">
 					<span class="font-bold">Next:</span>
 					<a 
-						href={nextPage.href}
+						href={nextPage.pathname}
 					class="text-main cursor-pointer hover:underline"
-					>{nextPage.title} →</a>
+					>{nextPage.rawTitle} →</a>
 			</div>
 			}
 			<div class="mt-16">

--- a/documentation/src/pages/[...content].astro
+++ b/documentation/src/pages/[...content].astro
@@ -3,7 +3,7 @@ import ContentTable from "@components/ContentTable.astro";
 import Layout from "@components/Layout.astro";
 import Header from "@components/ContentHeader.astro";
 
-import { getContent } from "@cela/content";
+import { getContent, getNextPage } from "@cela/content";
 import { frameworkIds } from "@lib/framework";
 import redirects from "redirects.json";
 import { error404 } from "@lib/error";
@@ -59,6 +59,11 @@ const contributePageHref = joinUrlPaths(
 	"https://github.com/pilcrowOnPaper/lucia/blob/main/documentation",
 	content.mappedContentPath
 );
+
+let collectionId = Astro.props.collectionId ?? "main";
+const currentPathname = Astro.url.pathname;
+
+const nextPage = await getNextPage(collectionId, frameworkId, currentPathname);
 ---
 
 <Layout
@@ -95,6 +100,14 @@ const contributePageHref = joinUrlPaths(
 			<MarkdownContent>
 				<content.Content />
 			</MarkdownContent>
+			{nextPage && <div class="mt-8 text-right">
+					<span class="font-bold">Next:</span>
+					<a 
+						href={nextPage.href}
+					class="text-main cursor-pointer hover:underline"
+					>{nextPage.title} →</a>
+			</div>
+			}
 			<div class="mt-16">
 				<div class="lg:hidden">
 					<a


### PR DESCRIPTION
Add a next button to the documentation content pages. This will add easier traversal through the docs.

Function was added so it can be used on any page. This could also be easily amended to pass back a previous page.

![image](https://user-images.githubusercontent.com/7026622/232340518-0b7e6c99-3072-4934-9a87-d997101995a5.png)
