### PR TITLE
Remove `Crypto` deps and provide polyfill

### DIFF
--- a/.auri/$jirnft2a.md
+++ b/.auri/$jirnft2a.md
@@ -1,6 +1,7 @@
 ---
 package: "lucia-auth" # package name
-type: "patch" # "major", "minor", "patch"
+type: "minor" # "major", "minor", "patch"
 ---
 
-Remove Node dependency
+Add `lucia-auth/polyfill/node`
+    - Remove Node dependency

--- a/.auri/$jirnft2a.md
+++ b/.auri/$jirnft2a.md
@@ -1,0 +1,6 @@
+---
+package: "lucia-auth" # package name
+type: "patch" # "major", "minor", "patch"
+---
+
+Remove Node dependency

--- a/documentation/content/main/start-here/getting-started.md
+++ b/documentation/content/main/start-here/getting-started.md
@@ -65,6 +65,39 @@ declare namespace Lucia {
 }
 ```
 
+## Polyfill `crypto`
+
+**This is only required for Node.js v16-18.** Import `lucia-auth/polyfill/node` in `lucia.ts`.
+
+```ts
+// auth/lucia.ts
+import lucia from "lucia-auth";
+import "lucia-auth/polyfill/node"
+
+// ...
+
+export const auth = lucia({
+	adapter: prisma(prismaClient),
+	env: process.env.NODE_ENV === "development" ? "DEV" : "PROD",
+	middleware: node()
+});
+
+export type Auth = typeof auth;
+```
+
+Alternatively, add the `--experimental-global-webcrypto` flag when running `node`:
+
+```
+node --experimental-global-webcrypto index.js
+```
+
+If you're using Node v14, you'll need to use a third party polyfill and set it as a global variable:
+
+```ts
+globalThis.crypto = cryptoPolyfill;
+```
+
+
 ## Next steps
 
 We recommend reading the "Basics" section from top to bottom to get the gist of the library. Cheers and happy coding!

--- a/documentation/content/main/start-here/getting-started.nextjs.md
+++ b/documentation/content/main/start-here/getting-started.nextjs.md
@@ -51,3 +51,43 @@ declare namespace Lucia {
 	type UserAttributes = {};
 }
 ```
+
+## Polyfill `crypto` global
+
+**This is only required for Node.js v16-18.** Import `lucia-auth/polyfill/node` in `lucia.ts`.
+
+```ts
+// auth/lucia.ts
+import lucia from "lucia-auth";
+import "lucia-auth/polyfill/node";
+
+// ...
+
+export const auth = lucia({
+	adapter: prisma(prismaClient),
+	env: process.env.NODE_ENV === "development" ? "DEV" : "PROD",
+	middleware: node()
+});
+
+export type Auth = typeof auth;
+```
+
+Alternatively, add the `--experimental-global-webcrypto` flag to the `dev` and `build` command:
+
+```json
+{
+	// ...
+	"scripts": {
+		"dev": "NODE_OPTIONS=--experimental-global-webcrypto next dev",
+		"start": "NODE_OPTIONS=--experimental-global-webcrypto next start"
+		// ...
+	}
+	// ...
+}
+```
+
+If you're using Node v14, you'll need to use a third party polyfill and set it as a global variable:
+
+```ts
+globalThis.crypto = cryptoPolyfill;
+```

--- a/documentation/content/main/start-here/introduction.md
+++ b/documentation/content/main/start-here/introduction.md
@@ -33,11 +33,27 @@ const session = await auth.createSession(user.userId);
 const sessionCookie = auth.createSessionCookie(session);
 ```
 
-Lucia aims to work well with any modern web framework and supports run-times other than Node such as Cloudflare edge workers.
-
 If you have any questions, feel free to ask in our [Discord server](https://discord.gg/PwrK3kpVR3)!
 
 > The name _Lucia_ is based on the country of Saint Lucia, so technically it's pronounced _loo-shya_. But based on a community poll, most people pronounce it _lu-si-a_. _loo-shya_, _lu-si-a_, _lu-chi-a_ your choice!
+
+## Runtime support
+
+While Lucia does not rely on any native Node.js module, it does require the [`Crypto` web API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API). It can be used without any configuration in the following runtimes:
+
+- Node.js v19 or later (see below)
+- Deno v1.18 or later
+- Cloudflare Workers (including Vercel Edge functions)
+- Bun v0.2.2 or later
+
+### Node.js support
+
+Lucia can be used with Node v16 or later when `crypto` global is polyfilled. This is already handled by the following frameworks:
+
+- SvelteKit
+- Astro
+
+If you're not using one of the listed frameworks above, you can use the polyfill provided by Lucia or by enabling a Node flag. Node v14 can be used as well, though the listed solution will not work.
 
 ## Official packages
 

--- a/documentation/content/main/start-here/migrate-to-version-1.md
+++ b/documentation/content/main/start-here/migrate-to-version-1.md
@@ -155,3 +155,45 @@ export const auth = lucia({
 All properties starting with `is` (`isExpired` etc) has had `is` removed (`expired` etc) to be more consistent with the JS/Node ecosystem, and `expires` has been renamed to `expiresAt` or `expiresIn` to be more consistent across packages.
 
 TypeScript should be able to detect most, if not all, of these changes.
+
+## Polyfill `crypto` global
+
+**This is only required for Node.js v16-18.** Import `lucia-auth/polyfill/node` in `lucia.ts`.
+
+```ts
+// auth/lucia.ts
+import lucia from "lucia-auth";
+import "lucia-auth/polyfill/node"
+
+// ...
+
+export const auth = lucia({
+	adapter: prisma(prismaClient),
+	env: process.env.NODE_ENV === "development" ? "DEV" : "PROD",
+	middleware: node()
+});
+
+export type Auth = typeof auth;
+```
+
+Alternatively, add the `--experimental-global-webcrypto` flag when running `node`:
+
+```
+node --experimental-global-webcrypto index.js
+```
+
+### Next.js
+
+Alternatively, add the `--experimental-global-webcrypto` flag to the `dev` and `build` command:
+
+```json
+{
+  // ...
+  "scripts": {
+    "dev": "NODE_OPTIONS=--experimental-global-webcrypto next dev",
+    "start": "NODE_OPTIONS=--experimental-global-webcrypto next start",
+	// ...
+  },
+  // ...
+}
+```

--- a/documentation/content/main/start-here/username-password.nextjs.md
+++ b/documentation/content/main/start-here/username-password.nextjs.md
@@ -111,7 +111,7 @@ Create `pages/api/signup.ts`. This API route will handle account creation.
 
 Calling [`handleRequest()`] will create a new [`AuthRequest`](/referencel/lucia-auth/authrequest) instance, which makes it easier to handle sessions and cookies. This can be initialized with `NextApiRequest` and `NextApiResponse`.
 
-Users can be created with `createUser()`. This will create a new primary key that can be used to authenticate user as well. We’ll use `"username"` as the provider id (authentication method) and the username as the provider user id (something unique to the user). Create a new session with [`createSession()`](/reference/lucia-auth/auth?framework=nextjs#createsession) and make sure to store the session id by calling [`setSession()`]().
+Users can be created with `createUser()`. This will create a new primary key that can be used to authenticate user as well. We’ll use `"username"` as the provider id (authentication method) and the username as the provider user id (something unique to the user). Create a new session with [`createSession()`](/reference/lucia-auth/auth?framework=nextjs#createsession) and make sure to store the session id by calling [`setSession()`](/reference/lucia-auth/authrequest#setsession).
 
 ```ts
 // pages/api/signup.ts

--- a/documentation/content/reference/lucia-auth/lucia-auth.md
+++ b/documentation/content/reference/lucia-auth/lucia-auth.md
@@ -27,10 +27,10 @@ Uses the following characters (uppercase, lowercase, numbers):
 
 #### Parameter
 
-| name     | type     | description                                   | optional |
-| -------- | -------- | --------------------------------------------- | -------- |
-| length   | `number` | the length of the output string               |          |
-| alphabet | `string` | a string from which to pick random characters | true     |
+| name     | type     | description                                   | optional | introduced |
+| -------- | -------- | --------------------------------------------- | -------- | ---------- |
+| length   | `number` | the length of the output string               |          |            |
+| alphabet | `string` | a string from which to pick random characters | true     | `1.1.0`    |
 
 #### Returns
 

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -3,9 +3,9 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"dev": "next dev",
+		"dev": "NODE_OPTIONS=--experimental-global-webcrypto next dev",
 		"build": "next build",
-		"start": "next start",
+		"start": "NODE_OPTIONS=--experimental-global-webcrypto next start",
 		"lint": "next lint"
 	},
 	"dependencies": {

--- a/packages/lucia-auth/package.json
+++ b/packages/lucia-auth/package.json
@@ -23,12 +23,16 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": "./index.js",
-		"./middleware": "./middleware/index.js"
+		"./middleware": "./middleware/index.js",
+		"./polyfill/node": "./polyfill/node.js"
 	},
 	"typesVersions": {
 		"*": {
 			"middleware": [
 				"middleware/index.d.ts"
+			],
+			"polyfill/node": [
+				"polyfill/node.d.ts"
 			]
 		}
 	},

--- a/packages/lucia-auth/src/polyfill/node.ts
+++ b/packages/lucia-auth/src/polyfill/node.ts
@@ -1,0 +1,5 @@
+import { webcrypto } from "crypto";
+
+if (!("crypto" in globalThis)) {
+	globalThis.crypto = webcrypto as any;
+}

--- a/packages/lucia-auth/src/scrypt/index.ts
+++ b/packages/lucia-auth/src/scrypt/index.ts
@@ -1,0 +1,226 @@
+import { pbkdf2 } from "./pbkdf.js";
+import { asyncLoop, checkOpts, u32 } from "./utils.js";
+
+const rotl = (a: number, b: number) => (a << b) | (a >>> (32 - b));
+
+const XorAndSalsa = (
+	prev: Uint32Array,
+	pi: number,
+	input: Uint32Array,
+	ii: number,
+	out: Uint32Array,
+	oi: number
+) => {
+	// Based on https://cr.yp.to/salsa20.html
+	const y00 = prev[pi++] ^ input[ii++],
+		y01 = prev[pi++] ^ input[ii++];
+	const y02 = prev[pi++] ^ input[ii++],
+		y03 = prev[pi++] ^ input[ii++];
+	const y04 = prev[pi++] ^ input[ii++],
+		y05 = prev[pi++] ^ input[ii++];
+	const y06 = prev[pi++] ^ input[ii++],
+		y07 = prev[pi++] ^ input[ii++];
+	const y08 = prev[pi++] ^ input[ii++],
+		y09 = prev[pi++] ^ input[ii++];
+	const y10 = prev[pi++] ^ input[ii++],
+		y11 = prev[pi++] ^ input[ii++];
+	const y12 = prev[pi++] ^ input[ii++],
+		y13 = prev[pi++] ^ input[ii++];
+	const y14 = prev[pi++] ^ input[ii++],
+		y15 = prev[pi++] ^ input[ii++];
+	let x00 = y00,
+		x01 = y01,
+		x02 = y02,
+		x03 = y03,
+		x04 = y04,
+		x05 = y05,
+		x06 = y06,
+		x07 = y07,
+		x08 = y08,
+		x09 = y09,
+		x10 = y10,
+		x11 = y11,
+		x12 = y12,
+		x13 = y13,
+		x14 = y14,
+		x15 = y15;
+	for (let i = 0; i < 8; i += 2) {
+		x04 ^= rotl((x00 + x12) | 0, 7);
+		x08 ^= rotl((x04 + x00) | 0, 9);
+		x12 ^= rotl((x08 + x04) | 0, 13);
+		x00 ^= rotl((x12 + x08) | 0, 18);
+		x09 ^= rotl((x05 + x01) | 0, 7);
+		x13 ^= rotl((x09 + x05) | 0, 9);
+		x01 ^= rotl((x13 + x09) | 0, 13);
+		x05 ^= rotl((x01 + x13) | 0, 18);
+		x14 ^= rotl((x10 + x06) | 0, 7);
+		x02 ^= rotl((x14 + x10) | 0, 9);
+		x06 ^= rotl((x02 + x14) | 0, 13);
+		x10 ^= rotl((x06 + x02) | 0, 18);
+		x03 ^= rotl((x15 + x11) | 0, 7);
+		x07 ^= rotl((x03 + x15) | 0, 9);
+		x11 ^= rotl((x07 + x03) | 0, 13);
+		x15 ^= rotl((x11 + x07) | 0, 18);
+		x01 ^= rotl((x00 + x03) | 0, 7);
+		x02 ^= rotl((x01 + x00) | 0, 9);
+		x03 ^= rotl((x02 + x01) | 0, 13);
+		x00 ^= rotl((x03 + x02) | 0, 18);
+		x06 ^= rotl((x05 + x04) | 0, 7);
+		x07 ^= rotl((x06 + x05) | 0, 9);
+		x04 ^= rotl((x07 + x06) | 0, 13);
+		x05 ^= rotl((x04 + x07) | 0, 18);
+		x11 ^= rotl((x10 + x09) | 0, 7);
+		x08 ^= rotl((x11 + x10) | 0, 9);
+		x09 ^= rotl((x08 + x11) | 0, 13);
+		x10 ^= rotl((x09 + x08) | 0, 18);
+		x12 ^= rotl((x15 + x14) | 0, 7);
+		x13 ^= rotl((x12 + x15) | 0, 9);
+		x14 ^= rotl((x13 + x12) | 0, 13);
+		x15 ^= rotl((x14 + x13) | 0, 18);
+	}
+	out[oi++] = (y00 + x00) | 0;
+	out[oi++] = (y01 + x01) | 0;
+	out[oi++] = (y02 + x02) | 0;
+	out[oi++] = (y03 + x03) | 0;
+	out[oi++] = (y04 + x04) | 0;
+	out[oi++] = (y05 + x05) | 0;
+	out[oi++] = (y06 + x06) | 0;
+	out[oi++] = (y07 + x07) | 0;
+	out[oi++] = (y08 + x08) | 0;
+	out[oi++] = (y09 + x09) | 0;
+	out[oi++] = (y10 + x10) | 0;
+	out[oi++] = (y11 + x11) | 0;
+	out[oi++] = (y12 + x12) | 0;
+	out[oi++] = (y13 + x13) | 0;
+	out[oi++] = (y14 + x14) | 0;
+	out[oi++] = (y15 + x15) | 0;
+};
+
+const BlockMix = (
+	input: Uint32Array,
+	ii: number,
+	out: Uint32Array,
+	oi: number,
+	r: number
+) => {
+	let head = oi + 0;
+	let tail = oi + 16 * r;
+	for (let i = 0; i < 16; i++) out[tail + i] = input[ii + (2 * r - 1) * 16 + i];
+	for (let i = 0; i < r; i++, head += 16, ii += 16) {
+		XorAndSalsa(out, tail, input, ii, out, head);
+		if (i > 0) tail += 16;
+		XorAndSalsa(out, head, input, (ii += 16), out, tail);
+	}
+};
+
+export type ScryptOpts = {
+	N: number;
+	r: number;
+	p: number;
+	dkLen?: number;
+	asyncTick?: number;
+	maxmem?: number;
+	onProgress?: (progress: number) => void;
+};
+
+const scryptInit = async (
+	password: Uint8Array,
+	salt: Uint8Array,
+	_opts?: ScryptOpts
+) => {
+	const opts = checkOpts(
+		{
+			dkLen: 32,
+			asyncTick: 10,
+			maxmem: 1024 ** 3 + 1024
+		},
+		_opts
+	);
+	const { N, r, p, dkLen, asyncTick, maxmem, onProgress } = opts;
+	if (onProgress !== undefined && typeof onProgress !== "function")
+		throw new Error("progressCb should be function");
+	const blockSize = 128 * r;
+	const blockSize32 = blockSize / 4;
+	if (
+		N <= 1 ||
+		(N & (N - 1)) !== 0 ||
+		N >= 2 ** (blockSize / 8) ||
+		N > 2 ** 32
+	) {
+		throw new Error(
+			"Scrypt: N must be larger than 1, a power of 2, less than 2^(128 * r / 8) and less than 2^32"
+		);
+	}
+	if (p < 0 || p > ((2 ** 32 - 1) * 32) / blockSize) {
+		throw new Error(
+			"Scrypt: p must be a positive integer less than or equal to ((2^32 - 1) * 32) / (128 * r)"
+		);
+	}
+	if (dkLen < 0 || dkLen > (2 ** 32 - 1) * 32) {
+		throw new Error(
+			"Scrypt: dkLen should be positive integer less than or equal to (2^32 - 1) * 32"
+		);
+	}
+	const memUsed = blockSize * (N + p);
+	if (memUsed > maxmem) {
+		throw new Error(
+			`Scrypt: parameters too large, ${memUsed} (128 * r * (N + p)) > ${maxmem} (maxmem)`
+		);
+	}
+	const B = await pbkdf2(password, salt, { c: 1, dkLen: blockSize * p });
+	console.log(B);
+	const B32 = u32(B);
+	const V = u32(new Uint8Array(blockSize * N));
+	const tmp = u32(new Uint8Array(blockSize));
+	let blockMixCb = () => {};
+	if (onProgress) {
+		const totalBlockMix = 2 * N * p;
+		const callbackPer = Math.max(Math.floor(totalBlockMix / 10000), 1);
+		let blockMixCnt = 0;
+		blockMixCb = () => {
+			blockMixCnt++;
+			if (
+				onProgress &&
+				(!(blockMixCnt % callbackPer) || blockMixCnt === totalBlockMix)
+			)
+				onProgress(blockMixCnt / totalBlockMix);
+		};
+	}
+	return { N, r, p, dkLen, blockSize32, V, B32, B, tmp, blockMixCb, asyncTick };
+};
+
+/**
+ * Scrypt KDF from RFC 7914.
+ */
+export const scrypt = async (
+	password: Uint8Array,
+	salt: Uint8Array,
+	opts: ScryptOpts
+) => {
+	const { N, r, p, dkLen, blockSize32, V, B32, B, tmp, blockMixCb, asyncTick } =
+		await scryptInit(password, salt, opts);
+	for (let pi = 0; pi < p; pi++) {
+		const Pi = blockSize32 * pi;
+		for (let i = 0; i < blockSize32; i++) V[i] = B32[Pi + i]; // V[0] = B[i]
+		let pos = 0;
+		await asyncLoop(N - 1, asyncTick, (i) => {
+			BlockMix(V, pos, V, (pos += blockSize32), r); // V[i] = BlockMix(V[i-1]);
+			blockMixCb();
+		});
+		BlockMix(V, (N - 1) * blockSize32, B32, Pi, r); // Process last element
+		blockMixCb();
+		await asyncLoop(N, asyncTick, (i) => {
+			// First u32 of the last 64-byte block (u32 is LE)
+			const j = B32[Pi + blockSize32 - 16] % N; // j = Integrify(X) % iterations
+			for (let k = 0; k < blockSize32; k++)
+				tmp[k] = B32[Pi + k] ^ V[j * blockSize32 + k]; // tmp = B ^ V[j]
+			BlockMix(tmp, 0, B32, Pi, r); // B = BlockMix(B ^ V[j])
+			blockMixCb();
+		});
+	}
+	const res = await pbkdf2(password, B, { c: 1, dkLen });
+	B.fill(0);
+	V.fill(0);
+	tmp.fill(0);
+	return res;
+};

--- a/packages/lucia-auth/src/scrypt/pbkdf.ts
+++ b/packages/lucia-auth/src/scrypt/pbkdf.ts
@@ -1,0 +1,28 @@
+export const pbkdf2 = async (
+	salt: Uint8Array,
+	password: Uint8Array,
+	options: {
+		c: number;
+		dkLen: number;
+	}
+) => {
+	const pwKey = await crypto.subtle.importKey(
+		"raw",
+		password,
+		"PBKDF2",
+		false,
+		["deriveBits"]
+	);
+	const keyBuffer = await crypto.subtle.deriveBits(
+		{
+			name: "PBKDF2",
+			hash: "SHA-256",
+			salt,
+			iterations: options.c
+		},
+		pwKey,
+		options.dkLen * 8
+	);
+
+	return new Uint8Array(keyBuffer);
+};

--- a/packages/lucia-auth/src/scrypt/utils.ts
+++ b/packages/lucia-auth/src/scrypt/utils.ts
@@ -1,0 +1,34 @@
+export const u32 = (arr: Uint8Array) =>
+	new Uint32Array(arr.buffer, arr.byteOffset, Math.floor(arr.byteLength / 4));
+
+export const nextTick = async () => {};
+
+const isPlainObject = (obj: any) =>
+	Object.prototype.toString.call(obj) === "[object Object]" &&
+	obj.constructor === Object;
+
+export function checkOpts<T1 extends {}, T2 extends {}>(
+	defaults: T1,
+	opts?: T2
+): T1 & T2 {
+	if (opts !== undefined && (typeof opts !== "object" || !isPlainObject(opts)))
+		throw new TypeError("Options should be object or undefined");
+	const merged = Object.assign(defaults, opts);
+	return merged as T1 & T2;
+}
+
+export const asyncLoop = async (
+	iters: number,
+	tick: number,
+	cb: (i: number) => void
+) => {
+	let ts = Date.now();
+	for (let i = 0; i < iters; i++) {
+		cb(i);
+		// Date.now() is not monotonic, so in case if clock goes backwards we return return control too
+		const diff = Date.now() - ts;
+		if (diff >= 0 && diff < tick) continue;
+		await nextTick();
+		ts += diff;
+	}
+};

--- a/test-apps/nextjs/package.json
+++ b/test-apps/nextjs/package.json
@@ -3,9 +3,9 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"dev": "next dev",
+		"dev": "NODE_OPTIONS=--experimental-global-webcrypto next dev",
 		"build": "next build",
-		"start": "next start",
+		"start": "NODE_OPTIONS=--experimental-global-webcrypto next start",
 		"lint": "next lint"
 	},
 	"dependencies": {


### PR DESCRIPTION
This PR removes all dependencies and replaces Node.js `Crypto` module with the `crypto` web API. To make sure Node.js is supported, it also adds a polyfill for Node.js v16+ users.

