### PR TITLE
docs: missing context in Nextjs username/password docs

### DIFF
--- a/documentation/content/main/start-here/username-password.nextjs.md
+++ b/documentation/content/main/start-here/username-password.nextjs.md
@@ -192,7 +192,7 @@ import React from "react";
 export const getServerSideProps = async (
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<{}>> => {
-	const authRequest = auth.handleRequest(req, res);
+	const authRequest = auth.handleRequest(context.req, context.res);
 	const session = await authRequest.validate();
 	if (session) {
 		// redirect the user if authenticated
@@ -326,7 +326,7 @@ import React from "react";
 export const getServerSideProps = async (
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<{}>> => {
-	const authRequest = auth.handleRequest(req, res);
+	const authRequest = auth.handleRequest(context.req, context.res);
 	const session = await authRequest.validate();
 	if (session) {
 		// redirect the user if authenticated
@@ -368,7 +368,7 @@ import type { User } from "lucia-auth";
 export const getServerSideProps = async (
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<{ user: User }>> => {
-	const authRequest = auth.handleRequest(req, res);
+	const authRequest = auth.handleRequest(context.req, context.res);
 	const { user } = await authRequest.validateUser();
 	if (!user)
 		return {


### PR DESCRIPTION
I found some minor mistakes in the example for nextjs username/password docs.The ```req, res``` is undefined in the code snippets when you try to use it. If you're like me, I usually copy paste docs and this fooled me for a solid 5 minutes. Ok it might be because I'm very new to Nextjs and Typescript but it wasted some time for me nonetheless. It's just so simple that I wanted to contribute. 

Great library. Easy to use. It just works especially with Prisma.