### PR TITLE
Improve OAuth providers types

### DIFF
--- a/.auri/$2mwosr64.md
+++ b/.auri/$2mwosr64.md
@@ -1,0 +1,7 @@
+---
+package: "@lucia-auth/oauth" # package name
+type: "patch" # "major", "minor", "patch"
+---
+
+Fix OAuth provider types
+    - Take `Auth` as a generic for every provider

--- a/packages/integration-oauth/src/providers/auth0.ts
+++ b/packages/integration-oauth/src/providers/auth0.ts
@@ -15,7 +15,7 @@ type Config = OAuthConfig & {
 	loginHint?: string;
 };
 
-export const auth0 = (auth: Auth, config: Config) => {
+export const auth0 = <A extends Auth>(auth: A, config: Config) => {
 	const getAuthorizationUrl = async (state: string) => {
 		const url = createUrl(new URL("/authorize", config.appDomain).toString(), {
 			client_id: config.clientId,

--- a/packages/integration-oauth/src/providers/discord.ts
+++ b/packages/integration-oauth/src/providers/discord.ts
@@ -10,7 +10,7 @@ type Config = OAuthConfig & {
 
 const PROVIDER_ID = "discord";
 
-export const discord = (auth: Auth, config: Config) => {
+export const discord = <A extends Auth>(auth: A, config: Config) => {
 	const getAuthorizationUrl = async (state: string) => {
 		const url = createUrl("https://discord.com/oauth2/authorize", {
 			response_type: "code",

--- a/packages/integration-oauth/src/providers/facebook.ts
+++ b/packages/integration-oauth/src/providers/facebook.ts
@@ -10,7 +10,7 @@ type Config = OAuthConfig & {
 
 const PROVIDER_ID = "facebook";
 
-export const facebook = (auth: Auth, config: Config) => {
+export const facebook = <A extends Auth>(auth: A, config: Config) => {
 	const getAuthorizationUrl = async (state: string) => {
 		const url = createUrl("https://www.facebook.com/v16.0/dialog/oauth", {
 			client_id: config.clientId,

--- a/packages/integration-oauth/src/providers/github.ts
+++ b/packages/integration-oauth/src/providers/github.ts
@@ -6,7 +6,7 @@ import type { OAuthConfig } from "../core.js";
 
 const PROVIDER_ID = "github";
 
-export const github = (auth: Auth, config: OAuthConfig) => {
+export const github = <A extends Auth>(auth: A, config: OAuthConfig) => {
 	const getAuthorizationUrl = async (state: string) => {
 		const url = createUrl("https://github.com/login/oauth/authorize", {
 			client_id: config.clientId,

--- a/packages/integration-oauth/src/providers/linkedin.ts
+++ b/packages/integration-oauth/src/providers/linkedin.ts
@@ -10,7 +10,7 @@ type Config = OAuthConfig & {
 	redirectUri: string;
 };
 
-export const linkedin = (auth: Auth, config: Config) => {
+export const linkedin = <A extends Auth>(auth: A, config: Config) => {
 	const getAuthorizationUrl = async (state: string) => {
 		const url = createUrl("https://www.linkedin.com/oauth/v2/authorization", {
 			client_id: config.clientId,


### PR DESCRIPTION
Google, Patreon, Reddit and Twitch have really nice typings taking Auth as a generic param:
```ts
export declare const google: <A extends Auth<any>>(auth: A, config: Config) => {
```
```ts
const { existingUser, providerUser, createUser } = await googleAuth.validateCallback(code);
typeof existingUser == { userId: string } | null
typeof createUser == (attributes: Lucia.UserAttributes) => Promise<{ userId: string }>
```
while other providers don't:
```ts
export declare const discord: (auth: Auth, config: Config) => {
```
```ts
const { existingUser, providerUser, createUser } = await githubAuth.validateCallback(code);
typeof existingUser == any
typeof createUser == (attributes: Lucia.UserAttributes) => Promise<any>
```
So this PR fixes that by introducing the better typings (taking `Auth` as a generic) to all providers.