### PR TITLE
fix(drizzle): correct schema definition

### DIFF
--- a/documentation/content/main/adapters/drizzle.md
+++ b/documentation/content/main/adapters/drizzle.md
@@ -57,7 +57,10 @@ export const key = mysqlTable("auth_key", {
 	primaryKey: boolean("primary_key").notNull(),
 	hashedPassword: varchar("hashed_password", {
 		length: 255
-	})
+	}),
+	expires: bigint("expires", {
+    mode: "number",
+  }),
 });
 ```
 


### PR DESCRIPTION
This small change adds the `expires` property for the `auth_key` model as it is required for authentication and it is missing from the drizzle schema.