### PR TITLE
Fix `better-sqlite3` and update Planetscale adapter peer dependency

### DIFF
--- a/.auri/$fxxzlhvj.md
+++ b/.auri/$fxxzlhvj.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/adapter-mysql" # package name
+type: "patch" # "major", "minor", "patch"
+---
+
+Set proper peer dependency

--- a/.auri/$ptnjnnk9.md
+++ b/.auri/$ptnjnnk9.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/adapter-sqlite" # package name
+type: "patch" # "major", "minor", "patch"
+---
+
+Fix `better-sqlite3` adapter only returning max 1 row

--- a/packages/adapter-mysql/package.json
+++ b/packages/adapter-mysql/package.json
@@ -40,7 +40,7 @@
 	"peerDependencies": {
 		"lucia-auth": "^1.4.0",
 		"mysql2": "^3.0.0",
-		"@planetscale/database": "^1.7.0"
+		"@planetscale/database": "^1.0.0"
 	},
 	"peerDependenciesMeta": {
 		"mysql2": {

--- a/packages/adapter-sqlite/src/better-sqlite3/runner.ts
+++ b/packages/adapter-sqlite/src/better-sqlite3/runner.ts
@@ -4,7 +4,7 @@ import type { Database } from "better-sqlite3";
 export const betterSqliteRunner = (db: Database): Runner => {
 	return {
 		get: async (query, params) => {
-			return db.prepare(query).get(params);
+			return db.prepare(query).all(params);
 		},
 		run: async (query, params) => {
 			db.prepare(query).run(params);


### PR DESCRIPTION
PlanetScale driver 1.7 does not work on Cloudflare workers - https://github.com/cloudflare/workers-sdk/issues/3005

Replaced `get()` with `all()` for `better-sqlite3`.