### PR TITLE
Term misusage

### DIFF
--- a/documentation/content/tokens/guides/two-factor-authorization.md
+++ b/documentation/content/tokens/guides/two-factor-authorization.md
@@ -1,9 +1,9 @@
 ---
-title: "Two-factor authorization"
-description: "Things to consider before implementing two-factor authorization"
+title: "Two-factor authentication"
+description: "Things to consider before implementing two-factor authentication"
 ---
 
-Two-factor authorization (2FA) is a great way to introduce an extra layer of security to your application. Both One-time passwords and magic links type 2FA can be implemented using [id tokens](/tokens/basics/id-tokens) and [password tokens](/tokens/basics/password-tokens).
+Two-factor authentication (2FA) is a great way to introduce an extra layer of security to your application. Both One-time passwords and magic links type 2FA can be implemented using [id tokens](/tokens/basics/id-tokens) and [password tokens](/tokens/basics/password-tokens).
 
 However, there are some things to consider before implementing it.
 
@@ -13,4 +13,4 @@ Social engineering is a tactic used to get access to important credentials, not 
 
 #### 2. SMS is unencrypted
 
-SMS verification is the only way to verify phone numbers. However, when considering it for 2FA, where a user could receive passwords multiple times a day, remember than SMS is not encrypted. Modern emails are generally encrypted in transit, though they're mostly stored unencrypted in the device.
+SMS verification is the only way to verify phone numbers. However, when considering it for 2FA, where a user could receive passwords multiple times a day, remember that SMS is not encrypted. Modern emails are generally encrypted in transit, though they're mostly stored unencrypted in the device.


### PR DESCRIPTION
The change was needed because "authentication" refers to verifying identity, while "authorization" is about granting access, and 2FA is about identity verification. The change also fixes the typo "than" to "that" in the last paragraph.