### PR TITLE
Replace dead links (fixes #593)

### DIFF
--- a/documentation/content/main/basics/configuration.md
+++ b/documentation/content/main/basics/configuration.md
@@ -210,7 +210,7 @@ type CookieOption = {
 
 #### `activePeriod`
 
-The time in milliseconds the [active period](/start-here/concepts#session-states) lasts for - or the time since session creation that it can be used.
+The time in milliseconds the [active period](/basics/sessions#session-states) lasts for - or the time since session creation that it can be used.
 
 | type     | default                          |
 | -------- | -------------------------------- |
@@ -218,7 +218,7 @@ The time in milliseconds the [active period](/start-here/concepts#session-states
 
 #### `idlePeriod`
 
-The time in milliseconds the [idle period](/start-here/concepts#session-states) lasts for - or the time since active period expiration that it can be renewed.
+The time in milliseconds the [idle period](/basics/sessions#session-states) lasts for - or the time since active period expiration that it can be renewed.
 
 | type     | default                              |
 | -------- | ------------------------------------ |


### PR DESCRIPTION
This replaces two links that lead to a 404 in the `/basics/configuration` page. Closes #593.