### PR TITLE
docs: fix Express usage in getting-started

### DIFF
--- a/documentation/content/main/start-here/getting-started.md
+++ b/documentation/content/main/start-here/getting-started.md
@@ -75,16 +75,16 @@ export const auth = lucia({
 
 ### Express
 
-Use the [Express middleware](/reference/lucia-auth/middleware#edge):
+If you are using Express for handling requests, use the [Express middleware](/reference/lucia-auth/middleware#express):
 
 ```ts
 import lucia from "lucia-auth";
-import { node } from "lucia-auth/middleware";
+import { express } from "lucia-auth/middleware";
 // ...
 
 export const auth = lucia({
 	//...
-	middleware: node()
+	middleware: express()
 });
 ```
 


### PR DESCRIPTION
Just to correct the usage of Express middleware in the docs, only in the Getting Started page. 

Might want to consider pointing users to `https://lucia-auth.com/reference/lucia-auth/middleware#<others>` for other usages, since the list is constantly being updated with new integrations.