### PR TITLE
docs: fix wrong example for `deleteKey()`

### DIFF
--- a/documentation/content/main/basics/keys.md
+++ b/documentation/content/main/basics/keys.md
@@ -170,7 +170,7 @@ You can delete a non-primary key with [`deleteKey()`](/reference/lucia-auth/auth
 
 ```ts
 try {
-	const key = await auth.updateKeyPassword("username", username, newPassword);
+	const key = await auth.deleteKey("username", username);
 } catch {
 	// invalid key
 }


### PR DESCRIPTION
Closes #608

Fixes wrong example for `deleteKey()` 