### PR TITLE
docs: fix deleteKey example

### DIFF
--- a/documentation/content/main/basics/keys.md
+++ b/documentation/content/main/basics/keys.md
@@ -170,7 +170,7 @@ You can delete a non-primary key with [`deleteKey()`](/reference/lucia-auth/auth
 
 ```ts
 try {
-	const key = await auth.deleteKey("username", username);
+	await auth.deleteKey("username", username);
 } catch {
 	// invalid key
 }


### PR DESCRIPTION
As mentioned in #610, we should remove the `const key = ` as it implies that `deleteKey()` returns a value.