### PR TITLE
CI: Release

### DIFF
--- a/.auri/$2pt1rkkg.md
+++ b/.auri/$2pt1rkkg.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Also adds the option to pass a default `redirectUri` to the github provider config.

--- a/.auri/$7oe1f15h.md
+++ b/.auri/$7oe1f15h.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/tokens" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Update types

--- a/.auri/$8nda6vqj.md
+++ b/.auri/$8nda6vqj.md
@@ -1,6 +1,0 @@
----
-package: "lucia-auth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-`web()` middleware can take `Headers` or `Response`

--- a/.auri/$f6ziamic.md
+++ b/.auri/$f6ziamic.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-`providerUser` respects scope and update `DiscordUser`

--- a/.auri/$fhi5x1dv.md
+++ b/.auri/$fhi5x1dv.md
@@ -1,6 +1,0 @@
----
-package: "lucia-auth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add `nextjs()` middleware

--- a/.auri/$gz64ds0f.md
+++ b/.auri/$gz64ds0f.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-postgresql" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Clean up adapter internals and remove rogue `console.log()`

--- a/.auri/$onuenc6v.md
+++ b/.auri/$onuenc6v.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update OAuth Provider type to allow for a custom `redirectUri` to be passed to `getAuthorizationUrl` and update all providers accordingly.

--- a/.auri/$xclxs0s6.md
+++ b/.auri/$xclxs0s6.md
@@ -1,6 +1,0 @@
----
-package: "lucia-auth" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix Express middleware returning broken url

--- a/packages/adapter-postgresql/CHANGELOG.md
+++ b/packages/adapter-postgresql/CHANGELOG.md
@@ -1,1 +1,7 @@
 # @lucia-auth/adapter-postgresql
+
+## 1.0.1
+
+### Patch changes
+
+- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Clean up adapter internals and remove rogue `console.log()`

--- a/packages/adapter-postgresql/package.json
+++ b/packages/adapter-postgresql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-postgresql",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "PostgreSQL adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/integration-oauth/CHANGELOG.md
+++ b/packages/integration-oauth/CHANGELOG.md
@@ -1,10 +1,23 @@
 # @lucia-auth/oauth
 
+## 1.1.0
+
+### Minor changes
+
+- [#628](https://github.com/pilcrowOnPaper/lucia/pull/628) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Also adds the option to pass a default `redirectUri` to the github provider config.
+
+- [#628](https://github.com/pilcrowOnPaper/lucia/pull/628) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update OAuth Provider type to allow for a custom `redirectUri` to be passed to `getAuthorizationUrl` and update all providers accordingly.
+
+### Patch changes
+
+- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : `providerUser` respects scope and update `DiscordUser`
+
 ## 1.0.1
 
 ### Patch changes
 
 - [#550](https://github.com/pilcrowOnPaper/lucia/pull/550) by [@pkb-pmj](https://github.com/pkb-pmj) : Fix OAuth provider types
+
   - Take `Auth` as a generic for every provider
 
 ## 1.0.0

--- a/packages/integration-oauth/package.json
+++ b/packages/integration-oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "OAuth integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/integration-tokens/CHANGELOG.md
+++ b/packages/integration-tokens/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/tokens
 
+## 1.0.2
+
+### Patch changes
+
+- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update types
+
 ## 1.0.1
 
 ### Patch changes

--- a/packages/integration-tokens/package.json
+++ b/packages/integration-tokens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/tokens",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Tokens integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/lucia-auth/CHANGELOG.md
+++ b/packages/lucia-auth/CHANGELOG.md
@@ -1,5 +1,17 @@
 # lucia-auth
 
+## 1.6.0
+
+### Minor changes
+
+- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : `web()` middleware can take `Headers` or `Response`
+
+- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `nextjs()` middleware
+
+### Patch changes
+
+- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix Express middleware returning broken url
+
 ## 1.5.0
 
 ### Minor changes

--- a/packages/lucia-auth/package.json
+++ b/packages/lucia-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia-auth",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "A simple and flexible authentication library",
 	"main": "index.js",
 	"types": "index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/oauth@1.1.0
#### Minor changes

- [#628](https://github.com/pilcrowOnPaper/lucia/pull/628) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Also adds the option to pass a default `redirectUri` to the github provider config.

- [#628](https://github.com/pilcrowOnPaper/lucia/pull/628) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update OAuth Provider type to allow for a custom `redirectUri` to be passed to `getAuthorizationUrl` and update all providers accordingly.

#### Patch changes

- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : `providerUser` respects scope and update `DiscordUser`
### @lucia-auth/tokens@1.0.2
#### Patch changes

- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update types
### lucia-auth@1.6.0
#### Minor changes

- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : `web()` middleware can take `Headers` or `Response`

- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `nextjs()` middleware

#### Patch changes

- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix Express middleware returning broken url
### @lucia-auth/adapter-postgresql@1.0.1
#### Patch changes

- [#626](https://github.com/pilcrowOnPaper/lucia/pull/626) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Clean up adapter internals and remove rogue `console.log()`