### PR TITLE
Docs: fix getting-started.remix.md

### DIFF
--- a/documentation/content/main/start-here/getting-started.remix.md
+++ b/documentation/content/main/start-here/getting-started.remix.md
@@ -35,7 +35,7 @@ In `auth/lucia.server.ts`, import [`lucia`](/reference/lucia-auth/auth) from `lu
 ```ts
 // auth/lucia.server.ts
 import lucia from "lucia-auth";
-import { nextjs } from "lucia-auth/middleware";
+import { web } from "lucia-auth/middleware";
 import prisma from "@lucia-auth/adapter-prisma";
 import { PrismaClient } from "@prisma/client";
 import { dev } from "$app/environment";

--- a/documentation/content/main/start-here/getting-started.remix.md
+++ b/documentation/content/main/start-here/getting-started.remix.md
@@ -38,7 +38,6 @@ import lucia from "lucia-auth";
 import { web } from "lucia-auth/middleware";
 import prisma from "@lucia-auth/adapter-prisma";
 import { PrismaClient } from "@prisma/client";
-import { dev } from "$app/environment";
 
 export const auth = lucia({
 	adapter: prisma(new PrismaClient()),


### PR DESCRIPTION
Thanks for the remix documentation!

I have made the following corrections.
- removed unused import
- middleware should specify web

```diff
diff --git a/documentation/content/main/start-here/getting-started.remix.md b/documentation/content/main/start-here/getting-started.remix.md
index 9405c53..5075245 100644
--- a/documentation/content/main/start-here/getting-started.remix.md
+++ b/documentation/content/main/start-here/getting-started.remix.md
@@ -35,10 +35,9 @@ In `auth/lucia.server.ts`, import [`lucia`](/reference/lucia-auth/auth) from `lu
 ```ts
 // auth/lucia.server.ts
 import lucia from "lucia-auth";
-import { nextjs } from "lucia-auth/middleware";
+import { web } from "lucia-auth/middleware";
 import prisma from "@lucia-auth/adapter-prisma";
 import { PrismaClient } from "@prisma/client";
-import { dev } from "$app/environment";
 
export const auth = lucia({
	adapter: prisma(new PrismaClient()),
	env: "DEV", // "PROD" if prod
	middleware: web()
});
```