### PR TITLE
Docs: fix missing table in the SQLite schema at drizzle.md

### DIFF
--- a/documentation/content/main/adapters/drizzle.md
+++ b/documentation/content/main/adapters/drizzle.md
@@ -202,7 +202,7 @@ const key = sqliteTable("auth_key", {
 	userId: text("user_id")
 		.notNull()
 		.references(() => user.id),
-	primaryKey: integer().notNull(),
+	primaryKey: integer("primary_key").notNull(),
 	hashedPassword: text("hashed_password"),
 	expires: integer("expires")
 });


### PR DESCRIPTION
fix Drizzle's SQLite schema

```diff
diff --git a/documentation/content/main/adapters/drizzle.md b/documentation/content/main/adapters/drizzle.md
index 81b787f..6743ac3 100644
--- a/documentation/content/main/adapters/drizzle.md
+++ b/documentation/content/main/adapters/drizzle.md
@@ -202,7 +202,7 @@ const key = sqliteTable("auth_key", {
        userId: text("user_id")
                .notNull()
                .references(() => user.id),
-       primaryKey: integer().notNull(),
+       primaryKey: integer("primary_key").notNull(),
        hashedPassword: text("hashed_password"),
        expires: integer("expires")
 });
```