### PR TITLE
fix `nextjs-app` oauth examples

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,8 +10,10 @@ node_modules
 /.auri/*.md
 /test-apps/*/.svelte-kit
 /test-apps/*/.next
+/test-apps/*/.nuxt
 /examples/*/.svelte-kit
 /examples/*/.next
+/examples/*/.nuxt
 /packages/*/dist
 
 # Ignore files for PNPM, NPM and YARN

--- a/documentation/content/main/basics/handle-requests.nextjs.md
+++ b/documentation/content/main/basics/handle-requests.nextjs.md
@@ -12,7 +12,7 @@ The [Next.js middleware](/reference/lucia-auth/middleware#nextjs) is the recomme
 
 ```ts
 // pages/index.tsx
-import { auth } from "./lucia.js";
+import { auth } from "../auth/lucia";
 
 export const getServerSideProps = async (context) => {
 	const authRequest = auth.handleRequest(context);
@@ -21,7 +21,7 @@ export const getServerSideProps = async (context) => {
 
 ```ts
 // pages/index.ts
-import { auth } from "./lucia.js";
+import { auth } from "../../auth/lucia";
 
 export default async (req, res) => {
 	const authRequest = auth.handleRequest({ req, res });
@@ -32,7 +32,7 @@ export default async (req, res) => {
 
 ```ts
 // app/page.tsx
-import { auth } from "auth/lucia.js";
+import { auth } from "@/auth/lucia";
 import { cookies } from "next/headers";
 
 export default () => {
@@ -44,7 +44,7 @@ export default () => {
 
 ```ts
 // app/routes.ts
-import { auth } from "auth/lucia.js";
+import { auth } from "@/auth/lucia";
 
 export const GET = async (request: Request) => {
 	const authRequest = auth.handleRequest({
@@ -87,11 +87,11 @@ const auth = lucia({
 [`AuthRequest.validateUser()`](/reference/lucia-auth/authrequest#validateuser) can be used to get the current session and user.
 
 ```ts
-// index.astro
-import { auth } from "./lucia.js";
+// index.ts
+import { auth } from "./lucia";
 
-const authRequest = auth.handleRequest(Astro);
-const { user, session } = await authRequest.validateUser(Astro);
+const authRequest = auth.handleRequest({ req, res });
+const { user, session } = await authRequest.validateUser();
 ```
 
 ### Caching
@@ -117,7 +117,7 @@ await Promise.all([authRequest.validateUser(), authRequest.validateUser()]);
 [`AuthRequest.setSession()`](/reference/lucia-auth/authrequest#validateuser) can be used to set a session, and therefore creating a session cookie.
 
 ```ts
-import { auth } from "./lucia.js";
+import { auth } from "./lucia";
 
 const authRequest = auth.handleRequest(req, res);
 authRequest.setSession(session);

--- a/documentation/content/main/basics/users.md
+++ b/documentation/content/main/basics/users.md
@@ -45,7 +45,7 @@ Refer to [Keys](/basics/keys) to learn more about keys.
 
 ### Create a primary key
 
-You can create primary keys alongside the user, which will be used when authenticating the user.s
+You can create primary keys alongside the user, which will be used when authenticating the user.
 
 #### With a password key
 

--- a/documentation/content/main/nextjs.nextjs/app-router.md
+++ b/documentation/content/main/nextjs.nextjs/app-router.md
@@ -24,7 +24,7 @@ export const auth = lucia({
 
 ```ts
 // app/page.tsx
-import { auth } from "auth/lucia.js";
+import { auth } from "@/auth/lucia";
 import { cookies } from "next/headers";
 
 export default () => {
@@ -40,7 +40,7 @@ export default () => {
 
 ```ts
 // app/routes.ts
-import { auth } from "auth/lucia.js";
+import { auth } from "@/auth/lucia";
 
 export const GET = async (request: Request) => {
 	const authRequest = auth.handleRequest({
@@ -58,7 +58,7 @@ Server actions are an alpha feature in Next.js that handles form actions. Lucia'
 
 ```ts
 // app/page.tsx
-import { auth } from "auth/lucia.js";
+import { auth } from "@/auth/lucia";
 import { cookies } from "next/headers";
 
 export default async () => {

--- a/documentation/content/main/nextjs.nextjs/pages-router-edge.md
+++ b/documentation/content/main/nextjs.nextjs/pages-router-edge.md
@@ -9,7 +9,7 @@ The response object is not available inside `getServerSideProps()` when deployed
 
 ```ts
 // pages/index.tsx
-import { auth } from "auth/lucia.js";
+import { auth } from "../auth/lucia";
 
 export const getServerSideProps = async (context) => {
 	const authRequest = auth.handleRequest(context);
@@ -23,7 +23,7 @@ You can call `handleRequest()` by passing on a [`Response`](https://developer.mo
 
 ```ts
 // pages/api/index.ts
-import { auth } from "auth/lucia.js";
+import { auth } from "../../auth/lucia";
 
 export default (request: Request) => {
 	const response = new Response();
@@ -37,7 +37,7 @@ export default (request: Request) => {
 
 ```ts
 // pages/api/index.ts
-import { auth } from "auth/lucia.js";
+import { auth } from "../../auth/lucia";
 
 export default (request: Request) => {
 	const headers = new Headers();

--- a/documentation/content/main/start-here/getting-started.nextjs.md
+++ b/documentation/content/main/start-here/getting-started.nextjs.md
@@ -57,13 +57,13 @@ This module and the file that holds it **should NOT be imported from the client*
 
 ### Types
 
-Create `lucia.d.ts`, and inside it configure your types. The path in `import('./auth/lucia.js').Auth;` is where you exported `auth` (`lucia()`).
+Create `lucia.d.ts`, and inside it configure your types. The path in `import('./auth/lucia').Auth;` is where you exported `auth` (`lucia()`).
 
 ```ts
 // lucia.d.ts
 /// <reference types="lucia-auth" />
 declare namespace Lucia {
-	type Auth = import("./auth/lucia.js").Auth;
+	type Auth = import("./auth/lucia").Auth;
 	type UserAttributes = {};
 }
 ```

--- a/documentation/content/oauth/start-here/getting-started.nextjs.md
+++ b/documentation/content/oauth/start-here/getting-started.nextjs.md
@@ -202,7 +202,7 @@ export const GET = async (request: Request) => {
 		const session = await auth.createSession(user.userId);
 		const authRequest = auth.handleRequest({ request, cookies });
 		authRequest.setSession(session);
-		return NextResponse.redirect(url.toString());
+		return NextResponse.redirect(new URL("/", url));
 	} catch (e) {
 		return new Response(null, {
 			status: 500

--- a/examples/nextjs-app/app/api/oauth/github/route.ts
+++ b/examples/nextjs-app/app/api/oauth/github/route.ts
@@ -24,7 +24,7 @@ export const GET = async (request: Request) => {
 		const session = await auth.createSession(user.userId);
 		const authRequest = auth.handleRequest({ request, cookies });
 		authRequest.setSession(session);
-		return NextResponse.redirect(url.toString());
+		return NextResponse.redirect(new URL("/", url));
 	} catch (e) {
 		return new Response(null, {
 			status: 500

--- a/examples/nextjs-app/lucia.d.ts
+++ b/examples/nextjs-app/lucia.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="lucia-auth" />
 declare namespace Lucia {
-	type Auth = import("./auth/lucia.js").Auth;
+	type Auth = import("./auth/lucia").Auth;
 	type UserAttributes = {
 		username: string;
 	};

--- a/examples/nextjs/lucia.d.ts
+++ b/examples/nextjs/lucia.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="lucia-auth" />
 declare namespace Lucia {
-	type Auth = import("./lib/lucia.js").Auth;
+	type Auth = import("./lib/lucia").Auth;
 	type UserAttributes = {
 		username: string;
 	};

--- a/test-apps/nextjs-app/app/api/oauth/github/route.ts
+++ b/test-apps/nextjs-app/app/api/oauth/github/route.ts
@@ -24,7 +24,7 @@ export const GET = async (request: Request) => {
 		const session = await auth.createSession(user.userId);
 		const authRequest = auth.handleRequest({ request, cookies });
 		authRequest.setSession(session);
-		return NextResponse.redirect(url.toString());
+		return NextResponse.redirect(new URL("/", url));
 	} catch (e) {
 		return new Response(null, {
 			status: 500

--- a/test-apps/nextjs-app/lucia.d.ts
+++ b/test-apps/nextjs-app/lucia.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="lucia-auth" />
 declare namespace Lucia {
-	type Auth = import("./auth/lucia.js").Auth;
+	type Auth = import("./auth/lucia").Auth;
 	type UserAttributes = {
 		username: string;
 	};

--- a/test-apps/nextjs/lucia.d.ts
+++ b/test-apps/nextjs/lucia.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="lucia-auth" />
 declare namespace Lucia {
-	type Auth = import("./auth/lucia.js").Auth;
+	type Auth = import("./auth/lucia").Auth;
 	type UserAttributes = {
 		username: string;
 	};


### PR DESCRIPTION
Some chore fixes:

- examples/test-apps: avoid circular request oauth token
- documents: fix typo
- format: ignore `.nuxt` path