### PR TITLE
Update google oauth provider scoping and providerUser model

### DIFF
--- a/.auri/config.json
+++ b/.auri/config.json
@@ -1,5 +1,0 @@
-{
-	"repository": "https://github.com/pilcrowOnPaper/lucia",
-	"ignore": ["*", "!packages", "packages/*/dist", "!documentation"],
-	"debug": true
-}

--- a/documentation/content/oauth/providers/google.md
+++ b/documentation/content/oauth/providers/google.md
@@ -117,11 +117,9 @@ type GoogleUser = {
 	sub: string;
 	name: string;
 	given_name: string;
-	family_name: string;
 	picture: string;
 	email: string;
 	email_verified: boolean;
 	locale: string;
-	hd: string;
 };
 ```

--- a/packages/integration-oauth/src/providers/google.ts
+++ b/packages/integration-oauth/src/providers/google.ts
@@ -53,7 +53,7 @@ export const google = <_Auth extends Auth>(auth: _Auth, config: Config) => {
 				client_id: config.clientId,
 				redirect_uri: redirectUri ?? config.redirectUri,
 				scope: scope(
-					["https://www.googleapis.com/auth/userinfo.profile"],
+					["https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email"],
 					config.scope
 				),
 				response_type: "code",
@@ -79,10 +79,8 @@ export type GoogleUser = {
 	sub: string;
 	name: string;
 	given_name: string;
-	family_name: string;
 	picture: string;
 	email: string;
 	email_verified: boolean;
 	locale: string;
-	hd: string;
 };


### PR DESCRIPTION
- [Breaking] Add an email scope to the Google OAuth provider and updates the fields of the `GoogleUser` type (fixes #676  )