### PR TITLE
Support Cloudflare KV Bindings as session adapter

### DIFF
--- a/documentation/content/main/adapters/cloudflare-kv-binding.md
+++ b/documentation/content/main/adapters/cloudflare-kv-binding.md
@@ -1,0 +1,89 @@
+---
+_order: 0
+title: "Cloudflare KV (Binding)"
+description: "Learn how to use Cloudflrae KV with Lucia"
+---
+
+A session adapter for Cloudlfare KV. A separate database/adapter is required for storing users and keys.
+
+```ts
+const adapter: (
+	ns: KVNamespace,
+	prefixes?: {
+		session: string;
+		userSessions: string;
+	}
+) => () => SessionAdapter;
+```
+
+### Parameter
+
+| name | type        | description                                          |
+| ---- | ----------- | ---------------------------------------------------- |
+| ns   | KvNamespace | Cloudflare KV Binding namespace for storing sessions |
+
+### Errors
+
+The adapter and Lucia will not not handle [unknown errors](/basics/error-handling#known-errors), which are database errors Lucia doesn't expect the adapter to catch. When it encounters such errors, it will throw one of the Redis errors.
+
+## Installation
+
+```
+npm i @lucia-auth/adapter-session-cloudflare-kv-binding
+pnpm add @lucia-auth/adapter-session-cloudflare-kv-binding
+yarn add @lucia-auth/adapter-session-cloudflare-kv-binding
+```
+
+For testing locally you can use [miniflare kv](https://www.npmjs.com/package/@miniflare/kv)
+
+```
+npm i -D @miniflare/kv @miniflare/storage-memory
+pnpm add -D @miniflare/kv @miniflare/storage-memory
+yarn add -D @miniflare/kv @miniflare/storage-memory
+```
+
+## Usage
+
+You will need to set up a different adapter for storing users.
+
+```ts
+// lucia.js
+import lucia from "lucia";
+import cloudflareKvBinding from "@lucia-auth/adapter-session-cloudflare-kv-binding";
+import prisma from "@lucia-auth/adapter-prisma";
+import { KVNamespace } from "@miniflare/kv";
+import { MemoryStorage } from "@miniflare/storage-memory";
+
+const ns = new KVNamespace(new MemoryStorage());
+
+export const auth = lucia({
+	adapter: {
+		user: prisma(), // any adapter
+		session: cloudflareKvBinding(ns)
+	}
+});
+```
+
+You will have to handle the database connection as well.
+
+```ts
+// db.ts
+import { sessionClient, userSessionClient } from "./lucia.js";
+
+sessionClient.connect();
+userSessionClient.connect();
+```
+
+## Models
+
+### `session`
+
+| key                  | value                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
+| session id: `string` | stringified [`SessionSchema`](/reference/lucia-auth/types#sessionschema#schema-type-1): `string` |
+
+### `userSession`
+
+| key               | value                           |
+| ----------------- | ------------------------------- |
+| user id: `string` | list of session ids: `string[]` |

--- a/packages/adapter-session-cloudflare-kv-binding/.gitignore
+++ b/packages/adapter-session-cloudflare-kv-binding/.gitignore
@@ -1,0 +1,5 @@
+/node_modules
+/dist
+.DS_Store
+.env
+*.tgz

--- a/packages/adapter-session-cloudflare-kv-binding/.prettierignore
+++ b/packages/adapter-session-cloudflare-kv-binding/.prettierignore
@@ -1,0 +1,13 @@
+.DS_Store
+node_modules
+/build
+/.svelte-kit
+/package
+.env
+.env.*
+!.env.example
+
+# Ignore files for PNPM, NPM and YARN
+pnpm-lock.yaml
+package-lock.json
+yarn.lock

--- a/packages/adapter-session-cloudflare-kv-binding/CHANGELOG.md
+++ b/packages/adapter-session-cloudflare-kv-binding/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @lucia-auth/adapter-session-cloudflare-kv

--- a/packages/adapter-session-cloudflare-kv-binding/README.md
+++ b/packages/adapter-session-cloudflare-kv-binding/README.md
@@ -1,0 +1,2 @@
+# `@lucia-auth/adapter-session-cloudflare-kv`
+

--- a/packages/adapter-session-cloudflare-kv-binding/package.json
+++ b/packages/adapter-session-cloudflare-kv-binding/package.json
@@ -1,0 +1,47 @@
+{
+	"name": "@lucia-auth/adapter-session-cloudflare-kv",
+	"version": "1.0.0",
+	"description": "Cloudflare KV session adapter for Lucia",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"module": "dist/index.js",
+	"type": "module",
+	"files": [
+		"/dist/",
+		"CHANGELOG.md"
+	],
+	"scripts": {
+		"build": "shx rm -rf ./dist/* && tsc",
+		"test": "tsx test/index.ts",
+		"auri.publish": "pnpm build && pnpm publish --no-git-checks --access public"
+	},
+	"keywords": [
+		"lucia",
+		"lucia",
+		"auth",
+		"authentication",
+		"adapter",
+		"cloudflare",
+		"session"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/pilcrowOnPaper/lucia",
+		"directory": "packages/adapter-session-cloudflare-kv"
+	},
+	"author": "pilcrowonpaper",
+	"license": "MIT",
+	"exports": {
+		".": "./dist/index.js"
+	},
+	"peerDependencies": {
+		"lucia": "^2.0.0"
+	},
+	"devDependencies": {
+		"@lucia-auth/adapter-test": "latest",
+		"@miniflare/kv": "^2.14.0",
+		"@miniflare/storage-memory": "^2.14.0",
+		"lucia": "latest",
+		"tsx": "^3.12.6"
+	}
+}

--- a/packages/adapter-session-cloudflare-kv-binding/src/cloudflare-kv-binding.ts
+++ b/packages/adapter-session-cloudflare-kv-binding/src/cloudflare-kv-binding.ts
@@ -1,0 +1,117 @@
+import type { SessionSchema, SessionAdapter, InitializeAdapter } from "lucia";
+import type { KVNamespace } from "@miniflare/kv";
+
+export const DEFAULT_SESSION_PREFIX = "session";
+export const DEFAULT_USER_SESSIONS_PREFIX = "user_sessions";
+
+export const sAdd = async (ns: KVNamespace, key: string, value: string) => {
+	const set: String[] | null = await ns.get(key, { type: "json" });
+
+	if (!set) {
+		const newSet = new Set([value]);
+		await ns.put(key, JSON.stringify([...newSet]));
+	} else {
+		const newSet = new Set([...set, value]);
+		await ns.put(key, JSON.stringify([...newSet]));
+	}
+};
+
+const sRem = async (ns: KVNamespace, key: string, value: string) => {
+	const set: String[] | null = await ns.get(key, { type: "json" });
+
+	if (set) {
+		const newSet = new Set([...set.filter((val) => val !== value)]);
+		await ns.put(key, JSON.stringify([...newSet]));
+	}
+};
+
+export const cloudflareKvBindingAdapter = (
+	ns: KVNamespace,
+	prefixes?: {
+		session: string;
+		userSessions: string;
+	}
+): InitializeAdapter<SessionAdapter> => {
+	return () => {
+		const sessionKey = (sessionId: string) => {
+			return [prefixes?.session ?? DEFAULT_SESSION_PREFIX, sessionId].join(":");
+		};
+		const userSessionsKey = (userId: string) => {
+			return [
+				prefixes?.userSessions ?? DEFAULT_USER_SESSIONS_PREFIX,
+				userId
+			].join(":");
+		};
+
+		return {
+			getSession: async (sessionId: string) => {
+				const sessionData = await ns.get(sessionKey(sessionId), {
+					type: "json"
+				});
+				if (!sessionData) return null;
+				const session = sessionData as SessionSchema;
+				return session;
+			},
+			getSessionsByUserId: async (userId: string) => {
+				const sessionIds: string[] =
+					(await ns.get(userSessionsKey(userId), { type: "json" })) || [];
+				const sessionData = await Promise.all(
+					sessionIds.map((sessionId: string) =>
+						ns.get(sessionKey(sessionId), { type: "json" })
+					)
+				);
+				const sessions = sessionData.filter(
+					(val: SessionSchema | null) => val !== null
+				) as SessionSchema[];
+				return sessions;
+			},
+			setSession: async (session: SessionSchema) => {
+				await Promise.all([
+					sAdd(ns, userSessionsKey(session.user_id), session.id),
+					ns.put(sessionKey(session.id), JSON.stringify(session), {
+						expirationTtl: Math.floor(Number(session.idle_expires) / 1000)
+					})
+				]);
+			},
+			deleteSession: async (sessionId: string) => {
+				const sessionData = await ns.get(sessionKey(sessionId), {
+					type: "json"
+				});
+				if (!sessionData) return;
+				const session = sessionData as SessionSchema;
+				await Promise.all([
+					ns.delete(sessionKey(sessionId)),
+					sRem(ns, userSessionsKey(session.user_id), sessionId)
+				]);
+			},
+			deleteSessionsByUserId: async (userId: string) => {
+				const sessionIds: string[] =
+					(await ns.get(userSessionsKey(userId), { type: "json" })) || [];
+
+				await Promise.all([
+					...sessionIds.map((sessionId: string) =>
+						ns.delete(sessionKey(sessionId))
+					),
+					ns.delete(userSessionsKey(userId))
+				]);
+			},
+			updateSession: async (
+				sessionId: string,
+				partialSession: Partial<SessionSchema>
+			) => {
+				const sessionData = await ns.get(sessionKey(sessionId), {
+					type: "json"
+				});
+				if (!sessionData) return;
+				const session = sessionData as SessionSchema;
+				const updatedSession = {
+					...session,
+					...partialSession
+				};
+				await ns.put(sessionKey(sessionId), JSON.stringify(updatedSession), {
+					expirationTtl: Math.floor(Number(updatedSession.idle_expires) / 1000)
+				});
+			}
+		};
+	};
+};

--- a/packages/adapter-session-cloudflare-kv-binding/src/index.ts
+++ b/packages/adapter-session-cloudflare-kv-binding/src/index.ts
@@ -1,0 +1,1 @@
+export { cloudflareKvBindingAdapter as cloudflareKvBinding } from "./cloudflare-kv-binding.js";

--- a/packages/adapter-session-cloudflare-kv-binding/src/lucia.d.ts
+++ b/packages/adapter-session-cloudflare-kv-binding/src/lucia.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="lucia" />
+declare namespace Lucia {
+	type Auth = any;
+	type DatabaseUserAttributes = any;
+	type DatabaseSessionAttributes = any;
+}

--- a/packages/adapter-session-cloudflare-kv-binding/test/index.ts
+++ b/packages/adapter-session-cloudflare-kv-binding/test/index.ts
@@ -1,0 +1,55 @@
+import { testSessionAdapter, Database } from "@lucia-auth/adapter-test";
+import { LuciaError } from "lucia";
+
+import { KVNamespace } from "@miniflare/kv";
+import { MemoryStorage } from "@miniflare/storage-memory";
+
+import {
+	cloudflareKvBindingAdapter,
+	DEFAULT_SESSION_PREFIX,
+	DEFAULT_USER_SESSIONS_PREFIX,
+	sAdd
+} from "../src/cloudflare-kv-binding.js";
+
+import type { QueryHandler } from "@lucia-auth/adapter-test";
+import type { SessionSchema } from "lucia";
+
+const ns = new KVNamespace(new MemoryStorage());
+
+const sessionKey = (sessionId: string) => {
+	return [DEFAULT_SESSION_PREFIX, sessionId].join(":");
+};
+const userSessionsKey = (userId: string) => {
+	return [DEFAULT_USER_SESSIONS_PREFIX, userId].join(":");
+};
+
+const adapter = cloudflareKvBindingAdapter(ns)(LuciaError);
+
+const queryHandler: QueryHandler = {
+	session: {
+		get: async () => {
+			const list = await ns.list({ prefix: sessionKey("") });
+			const sessionData = await Promise.all(
+				list.keys.map(({ name }) => ns.get(name, { type: "json" }))
+			);
+			const sessions = sessionData.filter(
+				(val: SessionSchema | null) => val !== null
+			);
+			return sessions;
+		},
+		insert: async (session) => {
+			await Promise.all([
+				ns.put(sessionKey(session.id), JSON.stringify(session)),
+				sAdd(ns, userSessionsKey(session.user_id), session.id)
+			]);
+		},
+		clear: async () => {
+			const list = await ns.list();
+			await Promise.all(list.keys.map(({ name }) => ns.delete(name)));
+		}
+	}
+};
+
+await testSessionAdapter(adapter, new Database(queryHandler));
+
+process.exit(0);

--- a/packages/adapter-session-cloudflare-kv-binding/tsconfig.json
+++ b/packages/adapter-session-cloudflare-kv-binding/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"noImplicitAny": true,
+		"module": "es2022",
+		"moduleResolution": "nodenext",
+		"target": "es2022",
+		"allowSyntheticDefaultImports": true,
+		"declaration": true,
+		"outDir": "./dist",
+		"strict": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules/", "**/__tests__/*"]
+}


### PR DESCRIPTION
# What?

On this PR we add support for [cloudflare KV Bindings](https://developers.cloudflare.com/workers/runtime-apis/kv/) as session adapter more or less like [redis session adapter works](https://lucia-auth.com/adapters/redis?nuxt)

![image](https://github.com/pilcrowOnPaper/lucia/assets/31882023/236cd605-49bd-44e4-9a62-974d60ef4d0e)
