### PR TITLE
docs: replace "drizzle-orm/planetscale" with "drizzle-orm/planetscale…

### DIFF
--- a/documentation/content/main/adapters/drizzle.md
+++ b/documentation/content/main/adapters/drizzle.md
@@ -92,7 +92,7 @@ Refer to the [`planetscale`](/adapters/mysql#planetscale) section.
 
 ```ts
 import { connect } from "@planetscale/database";
-import { drizzle } from "drizzle-orm/planetscale";
+import { drizzle } from "drizzle-orm/planetscale-serverless";
 import lucia from "lucia";
 import { planetscale } from "@lucia-auth/adapter-mysql";
 


### PR DESCRIPTION
use the current path which is "drizzle-orm/planetscale-serverless"