### PR TITLE
Added 'see also' for transformDatabaseUser

### DIFF
--- a/documentation/content/reference/lucia-auth/authrequest.md
+++ b/documentation/content/reference/lucia-auth/authrequest.md
@@ -76,6 +76,8 @@ if (session) {
 
 Validates the request, including a CSRF check if enabled (enabled by default), and return the current session and user. This method will also attempt to renew the session if it was invalid and return the new session if so.
 
+See also: [transformDatabaseUser()](/reference/lucia-auth/auth?sveltekit#transformdatabaseuser)
+
 ```ts
 const validate: () => Promise<{
 	session: Session;


### PR DESCRIPTION
It took me like half an hour of digging to figure out why validateUser() was returning an object with { objectId: string } instead of the entire user object. Added a link hint to help others who may be in the same shoes in the future.