### PR TITLE
Fix imported type Auth in app.d.ts in the Username/password example

### DIFF
--- a/documentation/content/main/start-here/username-password.sveltekit.md
+++ b/documentation/content/main/start-here/username-password.sveltekit.md
@@ -35,7 +35,7 @@ In `src/app.d.ts`, add `username` in `UserAttributes` since we added a `username
 /// <reference types="lucia" />
 declare global {
 	namespace Lucia {
-		type Auth = import("$lib/lucia").Auth;
+		type Auth = import("$lib/server/lucia").Auth;
 		type UserAttributes = {
 			username: string;
 		};


### PR DESCRIPTION
Since the Auth type is defined in `$lib/server/lucia.ts` it should be imported from there, because this type in `$lib/lucia` does not exist.