### PR TITLE
fix docs for handle-requests.sveltekit.md

### DIFF
--- a/documentation/content/main/basics/handle-requests.sveltekit.md
+++ b/documentation/content/main/basics/handle-requests.sveltekit.md
@@ -73,11 +73,14 @@ const auth = lucia({
 [`AuthRequest.validateUser()`](/reference/lucia-auth/authrequest#validateuser) can be used to get the current session and user.
 
 ```ts
-// index.astro
+// +page.server.ts
 import { auth } from "./lucia.js";
 
-const authRequest = auth.handleRequest(Astro);
-const { user, session } = await authRequest.validateUser(Astro);
+export const load = async (event) => {
+	const authRequest = auth.handleRequest(event);
+	const { user, session } = await authRequest.validateUser();
+};
+
 ```
 
 #### Examples
@@ -85,11 +88,15 @@ const { user, session } = await authRequest.validateUser(Astro);
 You create a new `AuthRequest` instance, or better yet, put it inside `locals` in the hooks handle.
 
 ```ts
-// +page.server.ts
+// hooks.server.ts
+import { auth } from "./lucia.js";
 
-export const load = async (event) => {
+export const handle = async (event) => {
 	const authRequest = auth.handleRequest(event);
+	event.locals.auth = authRequest;
 	const session = await authRequest.validateUser();
+	// ...
+	return await resolve(event);
 };
 ```
 
@@ -125,7 +132,7 @@ authRequest.setSession(session);
 You can also pass `null` to remove the current session cookie.
 
 ```ts
-authRequest.setSession(session);
+authRequest.setSession(null);
 ```
 
 > (warn) When signing users out, remember to invalidate the current session with [`invalidateSession()`](/reference/lucia-auth/auth#invalidatesession) alongside removing the session cookie!


### PR DESCRIPTION
This fixes two issues: First, some mentions of Astro in the SvelteKit doc need to be reworked to use SvelteKit (the text is fine but the code is not). Please review these changes carefully!

Second, the example in setSession with `null` is incorrect. This fix is straightforward.