### PR TITLE
Update `csrfProtection` config

### DIFF
--- a/.auri/$lfj0ueo5.md
+++ b/.auri/$lfj0ueo5.md
@@ -1,0 +1,6 @@
+---
+package: "lucia" # package name
+type: "major" # "major", "minor", "patch"
+---
+
+`Auth.validateRequestOrigin()` checks for CSRF regardless of `csrfProtection` config

--- a/packages/lucia/src/auth/index.ts
+++ b/packages/lucia/src/auth/index.ts
@@ -75,7 +75,7 @@ export class Auth<_Configuration extends Configuration = any> {
 	protected middleware: _Configuration["middleware"] extends Middleware
 		? _Configuration["middleware"]
 		: ReturnType<typeof defaultMiddleware>;
-	private csrfProtectionEnabled: boolean;
+	public csrfProtectionEnabled: boolean;
 	private requestOrigins: string[];
 	private experimental: {
 		debugMode: boolean;
@@ -523,10 +523,10 @@ export class Auth<_Configuration extends Configuration = any> {
 			debug.request.fail("Request url unavailable");
 			throw new LuciaError("AUTH_INVALID_REQUEST");
 		}
-		const csrfCheckRequired =
+		if (
 			request.method.toUpperCase() !== "GET" &&
-			request.method.toUpperCase() !== "HEAD";
-		if (this.csrfProtectionEnabled && csrfCheckRequired) {
+			request.method.toUpperCase() !== "HEAD"
+		) {
 			const requestOrigin = request.headers.origin;
 			if (!requestOrigin) {
 				debug.request.fail("No request origin available");

--- a/packages/lucia/src/auth/request.ts
+++ b/packages/lucia/src/auth/request.ts
@@ -32,7 +32,9 @@ export class AuthRequest<A extends Auth = any> {
 		this.auth = auth;
 		this.context = context;
 		try {
-			auth.validateRequestOrigin(context.request);
+			if (auth.csrfProtectionEnabled) {
+				auth.validateRequestOrigin(context.request);
+			}
 			this.storedSessionId =
 				context.request.storedSessionCookie ??
 				auth.readSessionCookie(context.request.headers.cookie);


### PR DESCRIPTION
`Auth.validateRequestOrigin()` will always check for CSRF regardless of config. `Auth.handleRequest()` will work as is.