### PR TITLE
CI: Release

### DIFF
--- a/.auri/$1cu5xxzs.md
+++ b/.auri/$1cu5xxzs.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Update `web()` middleware

--- a/.auri/$1y6p4pf3.md
+++ b/.auri/$1y6p4pf3.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Update `Auth.createSession()` params

--- a/.auri/$5x4qpfml.md
+++ b/.auri/$5x4qpfml.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Update `Auth.createKey()` params

--- a/.auri/$a2x3vpct.md
+++ b/.auri/$a2x3vpct.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Remove `AuthRequest.renewBearerToken()`

--- a/.auri/$duf8b04y.md
+++ b/.auri/$duf8b04y.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Update `nextjs()` middleware

--- a/.auri/$jfpx2rlj.md
+++ b/.auri/$jfpx2rlj.md
@@ -1,8 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Overhaul session renewal
-    - Remove `Auth.renewSession()`
-    - Add `sessionCookie.expires` configuration

--- a/.auri/$k0r7njuv.md
+++ b/.auri/$k0r7njuv.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Remove `generateUserId()` configuration

--- a/.auri/$kbvxwfic.md
+++ b/.auri/$kbvxwfic.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Update `ProviderUserAuth.createUser()` params

--- a/.auri/$lnise28p.md
+++ b/.auri/$lnise28p.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Add optional `userId` to `Auth.createUser()` params

--- a/documentation-v2/content/main/basics/sessions.md
+++ b/documentation-v2/content/main/basics/sessions.md
@@ -29,7 +29,7 @@ Sessions can be in one of 3 states:
 - Idle: A valid session but Lucia will reset the expiration. Becomes "dead" if the session is not used.
 - Dead: An invalid session. The user must sign in again.
 
-Instead of invalidating an idle session and creating a new one, Lucia will *reset* the session by extending the expiration.
+Instead of invalidating an idle session and creating a new one, Lucia will _reset_ the session by extending the expiration.
 
 This allows sessions to be persisted for active users, while invalidating inactive users. If you have used access tokens and refresh tokens, Lucia's sessions are a combination of both. Active sessions are your access tokens, and idle sessions are your refresh tokens.
 

--- a/documentation-v2/content/reference/lucia/interfaces.md
+++ b/documentation-v2/content/reference/lucia/interfaces.md
@@ -169,14 +169,14 @@ type Session = {
 
 `ReturnType<_Configuration["getSessionAttributes"]>` represents the return type of [`getSessionAttributes()`](/basics/configuration#getsessionattributes) configuration.
 
-| name                    | type                                       | description                                                                 |
-| ----------------------- | ------------------------------------------ | --------------------------------------------------------------------------- |
+| name                    | type                                       | description                                                                                    |
+| ----------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------- |
 | `activePeriodExpiresAt` | `Date`                                     | Time of the [active period](/start-here/concepts#session-states-and-session-resets) expiration |
 | `idlePeriodExpiresAt`   | `Date`                                     | Time of the [idle period](/start-here/concepts#session-states-and-session-resets) expiration   |
-| `fresh`                 | `boolean`                                  | `true` if the session was newly created or reset                            |
-| `sessionId`             | `string`                                   | Session id                                                                  |
+| `fresh`                 | `boolean`                                  | `true` if the session was newly created or reset                                               |
+| `sessionId`             | `string`                                   | Session id                                                                                     |
 | `state`                 | `"active" \| "idle"`                       | [Session state](/start-here/concepts#session-states-and-session-resets)                        |
-| `user`                  | [`User`](/reference/lucia/interfaces#user) | User of the session                                                         |
+| `user`                  | [`User`](/reference/lucia/interfaces#user) | User of the session                                                                            |
 
 ## `SessionAdapter`
 

--- a/packages/lucia/CHANGELOG.md
+++ b/packages/lucia/CHANGELOG.md
@@ -1,5 +1,28 @@
 # lucia
 
+## 2.0.0-beta.3
+
+### Major changes
+
+- [#773](https://github.com/pilcrowOnPaper/lucia/pull/773) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `web()` middleware
+
+- [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `Auth.createSession()` params
+
+- [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `Auth.createKey()` params
+
+- [#773](https://github.com/pilcrowOnPaper/lucia/pull/773) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `AuthRequest.renewBearerToken()`
+
+- [#773](https://github.com/pilcrowOnPaper/lucia/pull/773) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `nextjs()` middleware
+
+- [#773](https://github.com/pilcrowOnPaper/lucia/pull/773) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Overhaul session renewal
+
+  - Remove `Auth.renewSession()`
+  - Add `sessionCookie.expires` configuration
+
+- [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `generateUserId()` configuration
+
+- [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add optional `userId` to `Auth.createUser()` params
+
 ## 2.0.0-beta.2
 
 ### Major changes

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia",
-	"version": "2.0.0-beta.2",
+	"version": "2.0.0-beta.3",
 	"description": "A simple and flexible authentication library",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/oauth
 
+## 2.0.0-beta.4
+
+### Major changes
+
+- [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `ProviderUserAuth.createUser()` params
+
 ## 2.0.0-beta.3
 
 ### Major changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/src/core.ts
+++ b/packages/oauth/src/core.ts
@@ -14,8 +14,8 @@ export type OAuthProvider = {
 	) => Promise<{
 		existingUser: Record<any, any> | null;
 		createUser: (options: {
-			userId?: string,
-			attributes: Record<string, any>
+			userId?: string;
+			attributes: Record<string, any>;
 		}) => Promise<Record<any, any>>;
 		createKey: (userId: string) => Promise<Key>;
 	}>;


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### lucia@2.0.0-beta.3
#### Major changes

- [#773](https://github.com/pilcrowOnPaper/lucia/pull/773) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `web()` middleware

- [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `Auth.createSession()` params

- [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `Auth.createKey()` params

- [#773](https://github.com/pilcrowOnPaper/lucia/pull/773) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `AuthRequest.renewBearerToken()`

- [#773](https://github.com/pilcrowOnPaper/lucia/pull/773) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `nextjs()` middleware

- [#773](https://github.com/pilcrowOnPaper/lucia/pull/773) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Overhaul session renewal
    - Remove `Auth.renewSession()`
    - Add `sessionCookie.expires` configuration

- [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `generateUserId()` configuration

- [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add optional `userId` to `Auth.createUser()` params
### @lucia-auth/oauth@2.0.0-beta.4
#### Major changes

- [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `ProviderUserAuth.createUser()` params