### PR TITLE
Docs: Fixed AuthRequest import in SvelteKit docs

### DIFF
--- a/documentation-v2/content/main/start-here/getting-started/sveltekit.md
+++ b/documentation-v2/content/main/start-here/getting-started/sveltekit.md
@@ -107,7 +107,7 @@ Make sure to type `Locals` as well:
 declare global {
 	namespace App {
 		interface Locals {
-			auth: import("lucia").AuthRequest;
+			auth: import("lucia-auth").AuthRequest;
 		}
 	}
 }


### PR DESCRIPTION
Small fix on docs (SvelteKit Getting Started).
I believe the correct AuthRequest import is from 'lucia-auth' instead of 'lucia'.