### PR TITLE
Invalid code in username-password.sveltekit.md

### DIFF
--- a/documentation/content/main/start-here/username-password.sveltekit.md
+++ b/documentation/content/main/start-here/username-password.sveltekit.md
@@ -49,7 +49,7 @@ Add `transformDatabaseUser()` to your Lucia config to expose the user's id and u
 // lib/server/lucia.ts
 export const auth = lucia({
 	adapter: prisma(client),
-	env: "DEV" // "PROD" if prod,
+	env: "DEV", // "PROD" if prod
 	middleware: sveltekit(),
 	transformDatabaseUser: (userData) => {
 		return {


### PR DESCRIPTION
Comma is in the wrong place.

The comma is inside a comment making it unreachable and thereby breaking the code.

Fixed! :)