### PR TITLE
Fix `nextjs` middleware incorrect usage of `cookies` and `headers` with App Router

### DIFF
--- a/.auri/$pstcxjt3.md
+++ b/.auri/$pstcxjt3.md
@@ -1,0 +1,5 @@
+---
+package: "lucia" # package name
+type: "patch" # "major", "minor", "patch"
+---
+fix `nextjs` middleware runtime errors on app router

--- a/packages/lucia/src/middleware/index.ts
+++ b/packages/lucia/src/middleware/index.ts
@@ -210,26 +210,26 @@ type NextJsPagesServerContext = {
 	res: OutgoingMessage;
 };
 
-type NextJsCookie =
+type NextCookie =
 	| {
 			name: string;
 			value: string;
 	  }
 	| undefined;
 
-type RequestCookies = {
-	set?: (name: string, value: string, options: CookieAttributes) => void;
-	get: (name: string) => NextJsCookie;
+type NextCookiesFunction = () => {
+	set: (name: string, value: string, options: CookieAttributes) => void;
+	get: (name: string) => NextCookie;
 };
 
 type NextRequest = Request & {
 	cookies: {
-		get: (name: string) => NextJsCookie;
+		get: (name: string) => NextCookie;
 	};
 };
 
 type NextJsAppServerContext = {
-	cookies: () => RequestCookies;
+	cookies: NextCookiesFunction;
 	request: NextRequest | null;
 };
 


### PR DESCRIPTION
### What?
Fixed a couple of bugs where trying to use the `auth.handleRequest()` in either a server component or API Route Handler would result in a runtime error:

```bash
- error ../packages/lucia/dist/middleware/index.js (151:46) @ get
- error TypeError: cookieStore.get is not a function
    at eval (../../packages/lucia/dist/middleware/index.js:156:47)
    at Auth.handleRequest (../../packages/lucia/dist/auth/index.js:340:83)
    at Page (./app/page.tsx:19:71)
    at async Promise.all (index 0)
  149 |                 ? serverContext.cookies()
  150 |                 : serverContext.cookies;
> 151 |             const sessionCookie = cookieStore.get(cookieName)?.value ?? null;
      |                                              ^
  152 |             const requestContext = {
  153 |                 request: {
  154 |                     url: request?.url ?? "",
```

This was caused by an incorrect access of `cookie.get` in the `nextjs` middleware.

Additionally this also fixes a recurring error where the middleware was unable to access `request.headers.get`, which would also throw a runtime error anytime the middleware function was called by `auth.handleRequest()` in a context where `request` wasn't available (eg. server components):

```bash
- error ../packages/lucia/dist/middleware/index.js (157:49) @ get
- error TypeError: Cannot read properties of undefined (reading 'get')
    at eval (../../packages/lucia/dist/middleware/index.js:162:49)
    at Auth.handleRequest (../../packages/lucia/dist/auth/index.js:340:83)
    at Page (./app/page.tsx:19:71)
    at async Promise.all (index 0)
  155 |                     method: request?.method ?? "GET",
  156 |                     headers: {
> 157 |                         origin: request?.headers.get("Origin") ?? null,
      |                                                 ^
  158 |                         cookie: null,
  159 |                         authorization: request?.headers.get("Authorization") ?? null
  160 |                     },
```

### How?

When building the internal `cookieStore`, used `typeof` to check if the provided `cookies` is a callable function. Both will now securely have access to  `.get()`:

```typescript 
const cookieStore =
  typeof serverContext.cookies === "function"
    ? serverContext.cookies()
    : serverContext.cookies;
```

With this, we can correctly call `cookieStore.get()`.

For the headers, it was just a matter of using optional chaining to access `get()` in headers instead of trying to access it directly.

This was tested in both the `examples/nextjs` and `examples/nextjs-app` to ensure everything worked without breaking compatibility with Pages Router. Both tests were conducted using the latest versions of `lucia` and the database adapter by pointing the dependency in `package.json` to the workspace directory.