### PR TITLE
CI: Release

### DIFF
--- a/.auri/$73s2u151.md
+++ b/.auri/$73s2u151.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-sqlite" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$73s2u154.md
+++ b/.auri/$73s2u154.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-test" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$73s2u155.md
+++ b/.auri/$73s2u155.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$73s2u15a.md
+++ b/.auri/$73s2u15a.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mongoose" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$73s2u15c.md
+++ b/.auri/$73s2u15c.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mysql" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$73s2u15r.md
+++ b/.auri/$73s2u15r.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-postgresql" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$73s2u15y.md
+++ b/.auri/$73s2u15y.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-prisma" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$pstcxjt3.md
+++ b/.auri/$pstcxjt3.md
@@ -1,5 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-fix `nextjs` middleware runtime errors on app router

--- a/.auri/$shtopfi8.md
+++ b/.auri/$shtopfi8.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix `express()` middleware returning broken request url

--- a/documentation-v2/content/main/start-here/migrate-v2.md
+++ b/documentation-v2/content/main/start-here/migrate-v2.md
@@ -373,7 +373,6 @@ const { githubUser, githubTokens } = await githubAuth.validateCallback(code);
 
 `LuciaOAuthRequestError` is replaced with [`OAuthRequestError`](/reference/oauth/interfaces#oauthrequesterror).
 
-
 ### Update `ProviderUserAuth.validateCallback()`
 
 User attributes should be provided as its own property.

--- a/packages/adapter-mongoose/CHANGELOG.md
+++ b/packages/adapter-mongoose/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-mongoose
 
+## 3.0.0-beta.4
+
+### Patch changes
+
+- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 3.0.0-beta.3
 
 ### Major changes

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mongoose",
-	"version": "3.0.0-beta.3",
+	"version": "3.0.0-beta.4",
 	"description": "Mongoose (MongoDB) adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-mysql/CHANGELOG.md
+++ b/packages/adapter-mysql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-mysql
 
+## 2.0.0-beta.5
+
+### Patch changes
+
+- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.4
 
 ### Major changes

--- a/packages/adapter-mysql/package.json
+++ b/packages/adapter-mysql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mysql",
-	"version": "2.0.0-beta.4",
+	"version": "2.0.0-beta.5",
 	"description": "MySQL adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-postgresql/CHANGELOG.md
+++ b/packages/adapter-postgresql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-postgresql
 
+## 2.0.0-beta.4
+
+### Patch changes
+
+- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.3
 
 ### Major changes

--- a/packages/adapter-postgresql/package.json
+++ b/packages/adapter-postgresql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-postgresql",
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"description": "PostgreSQL adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-prisma/CHANGELOG.md
+++ b/packages/adapter-prisma/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-prisma
 
+## 3.0.0-beta.4
+
+### Patch changes
+
+- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 3.0.0-beta.3
 
 ### Major changes

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-prisma",
-	"version": "3.0.0-beta.3",
+	"version": "3.0.0-beta.4",
 	"description": "Prisma adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-sqlite/CHANGELOG.md
+++ b/packages/adapter-sqlite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-sqlite
 
+## 2.0.0-beta.4
+
+### Patch changes
+
+- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.3
 
 ### Major changes

--- a/packages/adapter-sqlite/package.json
+++ b/packages/adapter-sqlite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-sqlite",
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"description": "SQLite adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-test/CHANGELOG.md
+++ b/packages/adapter-test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-test
 
+## 4.0.0-beta.4
+
+### Patch changes
+
+- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 4.0.0-beta.3
 
 ### Major changes

--- a/packages/adapter-test/package.json
+++ b/packages/adapter-test/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-test",
-	"version": "4.0.0-beta.3",
+	"version": "4.0.0-beta.4",
 	"description": "Testing module for Lucia database adapters",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/lucia/CHANGELOG.md
+++ b/packages/lucia/CHANGELOG.md
@@ -1,5 +1,13 @@
 # lucia
 
+## 2.0.0-beta.4
+
+### Patch changes
+
+- [#799](https://github.com/pilcrowOnPaper/lucia/pull/799) by [@ernestoresende](https://github.com/ernestoresende) : fix `nextjs` middleware runtime errors on app router
+
+- [#801](https://github.com/pilcrowOnPaper/lucia/pull/801) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `express()` middleware returning broken request url
+
 ## 2.0.0-beta.3
 
 ### Major changes
@@ -17,6 +25,7 @@
 - [#773](https://github.com/pilcrowOnPaper/lucia/pull/773) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Overhaul session renewal
 
   - Remove `Auth.renewSession()`
+
   - Add `sessionCookie.expires` configuration
 
 - [#772](https://github.com/pilcrowOnPaper/lucia/pull/772) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `generateUserId()` configuration

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia",
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"description": "A simple and flexible authentication library",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/oauth
 
+## 2.0.0-beta.5
+
+### Patch changes
+
+- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.4
 
 ### Major changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "2.0.0-beta.4",
+	"version": "2.0.0-beta.5",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/adapter-sqlite@2.0.0-beta.4
#### Patch changes

- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-test@4.0.0-beta.4
#### Patch changes

- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/oauth@2.0.0-beta.5
#### Patch changes

- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-mongoose@3.0.0-beta.4
#### Patch changes

- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-mysql@2.0.0-beta.5
#### Patch changes

- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-postgresql@2.0.0-beta.4
#### Patch changes

- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-prisma@3.0.0-beta.4
#### Patch changes

- [#803](https://github.com/pilcrowOnPaper/lucia/pull/803) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### lucia@2.0.0-beta.4
#### Patch changes

- [#799](https://github.com/pilcrowOnPaper/lucia/pull/799) by [@ernestoresende](https://github.com/ernestoresende) : fix `nextjs` middleware runtime errors on app router

- [#801](https://github.com/pilcrowOnPaper/lucia/pull/801) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `express()` middleware returning broken request url