### PR TITLE
Updated SvelteKit Docs

### DIFF
--- a/documentation/content/main/start-here/getting-started.sveltekit.md
+++ b/documentation/content/main/start-here/getting-started.sveltekit.md
@@ -93,7 +93,7 @@ declare global {
 	namespace Lucia {
 		type Auth = import("$lib/server/lucia").Auth;
 		type UserAttributes = {};
-	}.
+	}
 }
 
 // THIS IS IMPORTANT!!!

--- a/documentation/content/main/start-here/getting-started.sveltekit.md
+++ b/documentation/content/main/start-here/getting-started.sveltekit.md
@@ -83,7 +83,7 @@ In `src/app.d.ts`, configure your types. The path in `import('$lib/server/lucia.
 declare global {
 	namespace App {
 		interface Locals {
-			auth: import("lucia").AuthRequest;
+			auth: import("lucia-auth").AuthRequest;
 		}
 	}
 }
@@ -93,7 +93,7 @@ declare global {
 	namespace Lucia {
 		type Auth = import("$lib/server/lucia").Auth;
 		type UserAttributes = {};
-	}
+	}.
 }
 
 // THIS IS IMPORTANT!!!

--- a/documentation/content/main/start-here/migrate-to-version-1.md
+++ b/documentation/content/main/start-here/migrate-to-version-1.md
@@ -75,7 +75,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 // app.d.ts
 /// <reference types="@sveltejs/kit" />
 declare namespace App {
-	type AuthRequest = import("lucia").AuthRequest;
+	type AuthRequest = import("lucia-auth").AuthRequest;
 	// Locals must be an interface and not a type
 	// eslint-disable-next-line @typescript-eslint/no-empty-interface
 	interface Locals extends AuthRequest {}

--- a/examples/sveltekit/github-oauth/src/app.d.ts
+++ b/examples/sveltekit/github-oauth/src/app.d.ts
@@ -3,7 +3,7 @@
 declare global {
 	namespace App {
 		interface Locals {
-			auth: import('lucia').AuthRequest;
+			auth: import('lucia-auth').AuthRequest;
 		}
 	}
 }

--- a/examples/sveltekit/username-and-password/src/app.d.ts
+++ b/examples/sveltekit/username-and-password/src/app.d.ts
@@ -3,7 +3,7 @@
 declare global {
 	namespace App {
 		interface Locals {
-			auth: import('lucia').AuthRequest;
+			auth: import('lucia-auth').AuthRequest;
 		}
 	}
 }


### PR DESCRIPTION
I ran into an issue where TypeScript couldn't determine the correct type for `locals.auth`:

```
export const load: LayoutServerLoad = async ({locals}) => {
    const { user } = await locals.auth.validateUser();
          // ^ any                ^ any       ^ any
	return {
		user,
             // ^ any
	};
};
```

After changing the `import('lucia').AuthRequest` to `import('lucia-auth').AuthRequest` the issue was resolved:
