### PR TITLE
CI: Release

### DIFF
--- a/.auri/$2.md
+++ b/.auri/$2.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Remove `allowedRequestOrigins` configuration

--- a/.auri/$72f6ffrt.md
+++ b/.auri/$72f6ffrt.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add osu! OAuth provider

--- a/.auri/$bl8xlo45.md
+++ b/.auri/$bl8xlo45.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-sqlite" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Make `session` model name params optional for `betterSqlite3()`, `d1()`, `libsql()`

--- a/.auri/$bl8xlo53.md
+++ b/.auri/$bl8xlo53.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-postgresql" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Make `session` model name params optional for `pg()` and `postgres()`

--- a/.auri/$bl8xlop1.md
+++ b/.auri/$bl8xlop1.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mysql" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Make `session` model name params optional for `mysql2()` and `planetscale()`

--- a/.auri/$bl8xlope.md
+++ b/.auri/$bl8xlope.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-prisma" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Make `session` model name params optional

--- a/.auri/$bl8xlops.md
+++ b/.auri/$bl8xlops.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mongoose" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Make `Session` model params optional

--- a/.auri/$n68qqjen.md
+++ b/.auri/$n68qqjen.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix `getSessionAndUser()` adapter method getting called when using session adapters

--- a/.auri/$r.md
+++ b/.auri/$r.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mongoose" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$toles4.md
+++ b/.auri/$toles4.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mysql" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$tolesr2.md
+++ b/.auri/$tolesr2.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-postgresql" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$tolesr3.md
+++ b/.auri/$tolesr3.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-prisma" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$tolesrm1.md
+++ b/.auri/$tolesrm1.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-session-redis" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$tolesrm2.md
+++ b/.auri/$tolesrm2.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-sqlite" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$tolesrm6.md
+++ b/.auri/$tolesrm6.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-test" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$tolesrm6r.md
+++ b/.auri/$tolesrm6r.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/documentation-v2/content/reference/lucia/interfaces/auth.md
+++ b/documentation-v2/content/reference/lucia/interfaces/auth.md
@@ -741,7 +741,7 @@ const key = await auth.useKey("github", githubUserId, null);
 
 ## `validateRequestOrigin()`
 
-Used for CSRF protection. Checks if the request origin is trusted for non-GET and non-HEAD requests (e.g. POST, PUT, DELETE), and throws an error if the origin is invalid.  Trusted origins include where the server is hosted and its subdomains defined with [`csrfProtection.allowedSubdomains`](/basics/configuration#csrfprotection) configuration.
+Used for CSRF protection. Checks if the request origin is trusted for non-GET and non-HEAD requests (e.g. POST, PUT, DELETE), and throws an error if the origin is invalid. Trusted origins include where the server is hosted and its subdomains defined with [`csrfProtection.allowedSubdomains`](/basics/configuration#csrfprotection) configuration.
 
 ```ts
 const validateRequestOrigin: (request: {

--- a/packages/adapter-mongoose/CHANGELOG.md
+++ b/packages/adapter-mongoose/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lucia-auth/adapter-mongoose
 
+## 3.0.0-beta.5
+
+### Minor changes
+
+- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Make `Session` model params optional
+
+- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 3.0.0-beta.4
 
 ### Patch changes

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mongoose",
-	"version": "3.0.0-beta.4",
+	"version": "3.0.0-beta.5",
 	"description": "Mongoose (MongoDB) adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-mysql/CHANGELOG.md
+++ b/packages/adapter-mysql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lucia-auth/adapter-mysql
 
+## 2.0.0-beta.6
+
+### Minor changes
+
+- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Make `session` model name params optional for `mysql2()` and `planetscale()`
+
+- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.5
 
 ### Patch changes

--- a/packages/adapter-mysql/package.json
+++ b/packages/adapter-mysql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mysql",
-	"version": "2.0.0-beta.5",
+	"version": "2.0.0-beta.6",
 	"description": "MySQL adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-mysql/src/drivers/mysql2.ts
+++ b/packages/adapter-mysql/src/drivers/mysql2.ts
@@ -25,7 +25,9 @@ export const mysql2Adapter = (
 	}
 ): InitializeAdapter<Adapter> => {
 	const ESCAPED_USER_TABLE_NAME = escapeName(tables.user);
-	const ESCAPED_SESSION_TABLE_NAME = tables.session ? escapeName(tables.session): null;
+	const ESCAPED_SESSION_TABLE_NAME = tables.session
+		? escapeName(tables.session)
+		: null;
 	const ESCAPED_KEY_TABLE_NAME = escapeName(tables.key);
 
 	const transaction = async <
@@ -106,7 +108,7 @@ export const mysql2Adapter = (
 
 			getSession: async (sessionId) => {
 				if (!ESCAPED_SESSION_TABLE_NAME) {
-					throw new Error("Session table not defined")
+					throw new Error("Session table not defined");
 				}
 				const result = await get<SessionSchema>(
 					db.query(`SELECT * FROM ${ESCAPED_SESSION_TABLE_NAME} WHERE id = ?`, [
@@ -117,7 +119,7 @@ export const mysql2Adapter = (
 			},
 			getSessionsByUserId: async (userId) => {
 				if (!ESCAPED_SESSION_TABLE_NAME) {
-					throw new Error("Session table not defined")
+					throw new Error("Session table not defined");
 				}
 				const result = await getAll<SessionSchema>(
 					db.query(
@@ -129,7 +131,7 @@ export const mysql2Adapter = (
 			},
 			setSession: async (session) => {
 				if (!ESCAPED_SESSION_TABLE_NAME) {
-					throw new Error("Session table not defined")
+					throw new Error("Session table not defined");
 				}
 				try {
 					const [fields, values, args] = helper(session);
@@ -147,7 +149,7 @@ export const mysql2Adapter = (
 			},
 			deleteSession: async (sessionId) => {
 				if (!ESCAPED_SESSION_TABLE_NAME) {
-					throw new Error("Session table not defined")
+					throw new Error("Session table not defined");
 				}
 				await db.execute(
 					`DELETE FROM ${ESCAPED_SESSION_TABLE_NAME} WHERE id = ?`,
@@ -156,7 +158,7 @@ export const mysql2Adapter = (
 			},
 			deleteSessionsByUserId: async (userId) => {
 				if (!ESCAPED_SESSION_TABLE_NAME) {
-					throw new Error("Session table not defined")
+					throw new Error("Session table not defined");
 				}
 				await db.execute(
 					`DELETE FROM ${ESCAPED_SESSION_TABLE_NAME} WHERE user_id = ?`,
@@ -165,7 +167,7 @@ export const mysql2Adapter = (
 			},
 			updateSession: async (sessionId, partialSession) => {
 				if (!ESCAPED_SESSION_TABLE_NAME) {
-					throw new Error("Session table not defined")
+					throw new Error("Session table not defined");
 				}
 				const [fields, values, args] = helper(partialSession);
 				await db.execute(
@@ -240,7 +242,7 @@ export const mysql2Adapter = (
 
 			getSessionAndUser: async (sessionId) => {
 				if (!ESCAPED_SESSION_TABLE_NAME) {
-					throw new Error("Session table not defined")
+					throw new Error("Session table not defined");
 				}
 				const getSessionPromise = get<SessionSchema>(
 					db.query(`SELECT * FROM ${ESCAPED_SESSION_TABLE_NAME} WHERE id = ?`, [

--- a/packages/adapter-postgresql/CHANGELOG.md
+++ b/packages/adapter-postgresql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lucia-auth/adapter-postgresql
 
+## 2.0.0-beta.6
+
+### Minor changes
+
+- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Make `session` model name params optional for `pg()` and `postgres()`
+
+- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.5
 
 ### Minor changes

--- a/packages/adapter-postgresql/package.json
+++ b/packages/adapter-postgresql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-postgresql",
-	"version": "2.0.0-beta.5",
+	"version": "2.0.0-beta.6",
 	"description": "PostgreSQL adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-postgresql/src/drivers/pg.ts
+++ b/packages/adapter-postgresql/src/drivers/pg.ts
@@ -38,7 +38,9 @@ export const pgAdapter = (
 	};
 
 	const ESCAPED_USER_TABLE_NAME = escapeName(tables.user);
-	const ESCAPED_SESSION_TABLE_NAME = tables.session ? escapeName(tables.session): null;
+	const ESCAPED_SESSION_TABLE_NAME = tables.session
+		? escapeName(tables.session)
+		: null;
 	const ESCAPED_KEY_TABLE_NAME = escapeName(tables.key);
 
 	return (LuciaError) => {

--- a/packages/adapter-postgresql/src/drivers/postgres.ts
+++ b/packages/adapter-postgresql/src/drivers/postgres.ts
@@ -18,7 +18,9 @@ export const postgresAdapter = (
 	}
 ): InitializeAdapter<Adapter> => {
 	const ESCAPED_USER_TABLE_NAME = escapeName(tables.user);
-	const ESCAPED_SESSION_TABLE_NAME = tables.session ? escapeName(tables.session): null;
+	const ESCAPED_SESSION_TABLE_NAME = tables.session
+		? escapeName(tables.session)
+		: null;
 	const ESCAPED_KEY_TABLE_NAME = escapeName(tables.key);
 
 	return (LuciaError) => {

--- a/packages/adapter-prisma/CHANGELOG.md
+++ b/packages/adapter-prisma/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lucia-auth/adapter-prisma
 
+## 3.0.0-beta.5
+
+### Minor changes
+
+- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Make `session` model name params optional
+
+- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 3.0.0-beta.4
 
 ### Patch changes

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-prisma",
-	"version": "3.0.0-beta.4",
+	"version": "3.0.0-beta.5",
 	"description": "Prisma adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-session-redis/CHANGELOG.md
+++ b/packages/adapter-session-redis/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-session-redis
 
+## 2.0.0-beta.6
+
+### Minor changes
+
+- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.5
 
 ### Minor changes

--- a/packages/adapter-session-redis/package.json
+++ b/packages/adapter-session-redis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-session-redis",
-	"version": "2.0.0-beta.5",
+	"version": "2.0.0-beta.6",
 	"description": "Redis session adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-sqlite/CHANGELOG.md
+++ b/packages/adapter-sqlite/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lucia-auth/adapter-sqlite
 
+## 2.0.0-beta.6
+
+### Minor changes
+
+- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Make `session` model name params optional for `betterSqlite3()`, `d1()`, `libsql()`
+
+- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.5
 
 ### Minor changes

--- a/packages/adapter-sqlite/package.json
+++ b/packages/adapter-sqlite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-sqlite",
-	"version": "2.0.0-beta.5",
+	"version": "2.0.0-beta.6",
 	"description": "SQLite adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-sqlite/src/drivers/better-sqlite3.ts
+++ b/packages/adapter-sqlite/src/drivers/better-sqlite3.ts
@@ -34,7 +34,9 @@ export const betterSqlite3Adapter = (
 	};
 
 	const ESCAPED_USER_TABLE_NAME = escapeName(tables.user);
-	const ESCAPED_SESSION_TABLE_NAME = tables.session ? escapeName(tables.session): null;
+	const ESCAPED_SESSION_TABLE_NAME = tables.session
+		? escapeName(tables.session)
+		: null;
 	const ESCAPED_KEY_TABLE_NAME = escapeName(tables.key);
 
 	return (LuciaError) => {

--- a/packages/adapter-sqlite/src/drivers/d1.ts
+++ b/packages/adapter-sqlite/src/drivers/d1.ts
@@ -18,7 +18,9 @@ export const d1Adapter = (
 	}
 ): InitializeAdapter<Adapter> => {
 	const ESCAPED_USER_TABLE_NAME = escapeName(tables.user);
-	const ESCAPED_SESSION_TABLE_NAME = tables.session ? escapeName(tables.session): null;
+	const ESCAPED_SESSION_TABLE_NAME = tables.session
+		? escapeName(tables.session)
+		: null;
 	const ESCAPED_KEY_TABLE_NAME = escapeName(tables.key);
 
 	return (LuciaError) => {

--- a/packages/adapter-sqlite/src/drivers/libsql.ts
+++ b/packages/adapter-sqlite/src/drivers/libsql.ts
@@ -18,7 +18,9 @@ export const libsqlAdapter = (
 	}
 ): InitializeAdapter<Adapter> => {
 	const ESCAPED_USER_TABLE_NAME = escapeName(tables.user);
-	const ESCAPED_SESSION_TABLE_NAME = tables.session ? escapeName(tables.session): null;
+	const ESCAPED_SESSION_TABLE_NAME = tables.session
+		? escapeName(tables.session)
+		: null;
 	const ESCAPED_KEY_TABLE_NAME = escapeName(tables.key);
 
 	return (LuciaError) => {

--- a/packages/adapter-test/CHANGELOG.md
+++ b/packages/adapter-test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-test
 
+## 4.0.0-beta.5
+
+### Minor changes
+
+- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 4.0.0-beta.4
 
 ### Patch changes

--- a/packages/adapter-test/package.json
+++ b/packages/adapter-test/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-test",
-	"version": "4.0.0-beta.4",
+	"version": "4.0.0-beta.5",
 	"description": "Testing module for Lucia database adapters",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/lucia/CHANGELOG.md
+++ b/packages/lucia/CHANGELOG.md
@@ -1,5 +1,15 @@
 # lucia
 
+## 2.0.0-beta.5
+
+### Major changes
+
+- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `allowedRequestOrigins` configuration
+
+### Patch changes
+
+- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `getSessionAndUser()` adapter method getting called when using session adapters
+
 ## 2.0.0-beta.4
 
 ### Patch changes

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia",
-	"version": "2.0.0-beta.4",
+	"version": "2.0.0-beta.5",
 	"description": "A simple and flexible authentication library",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/lucia/src/auth/index.ts
+++ b/packages/lucia/src/auth/index.ts
@@ -92,8 +92,7 @@ export class Auth<_Configuration extends Configuration = any> {
 			let sessionAdapter = config.adapter.session(LuciaError);
 
 			if ("getSessionAndUser" in userAdapter) {
-				const { getSessionAndUser: _, ...extractedUserAdapter } =
-					userAdapter;
+				const { getSessionAndUser: _, ...extractedUserAdapter } = userAdapter;
 				userAdapter = extractedUserAdapter;
 			}
 

--- a/packages/lucia/src/utils/url.test.ts
+++ b/packages/lucia/src/utils/url.test.ts
@@ -1,117 +1,167 @@
 import { test, expect } from "vitest";
-import {
-	isAllowedUrl
-} from "./url.js";
+import { isAllowedUrl } from "./url.js";
 
 test("isAllowedUrl() returns expected result", async () => {
-	expect(isAllowedUrl("http://example.com", {
-		url: "http://example.com",
-		allowedSubdomains: []
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.example.com", {
-		url: "http://foo.example.com",
-		allowedSubdomains: []
-	})).toBe(true)
-	expect(isAllowedUrl("http://not-allowed.com", {
-		url: "http://example.com",
-		allowedSubdomains: []
-	})).toBe(false)
-	expect(isAllowedUrl("http://localhost:3000", {
-		url: "http://example.com",
-		allowedSubdomains: []
-	})).toBe(false)
-	expect(isAllowedUrl("http://example.", {
-		url: "http://example.com",
-		allowedSubdomains: []
-	})).toBe(false)
+	expect(
+		isAllowedUrl("http://example.com", {
+			url: "http://example.com",
+			allowedSubdomains: []
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.example.com", {
+			url: "http://foo.example.com",
+			allowedSubdomains: []
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://not-allowed.com", {
+			url: "http://example.com",
+			allowedSubdomains: []
+		})
+	).toBe(false);
+	expect(
+		isAllowedUrl("http://localhost:3000", {
+			url: "http://example.com",
+			allowedSubdomains: []
+		})
+	).toBe(false);
+	expect(
+		isAllowedUrl("http://example.", {
+			url: "http://example.com",
+			allowedSubdomains: []
+		})
+	).toBe(false);
 
-	expect(isAllowedUrl("http://example.com/foo", {
-		url: "http://example.com/foo/bar",
-		allowedSubdomains: "*"
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.example.com", {
-		url: "http://example.com",
-		allowedSubdomains: "*"
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.example.com", {
-		url: "http://bar.example.com",
-		allowedSubdomains: "*"
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.bar.example.com", {
-		url: "http://example.com",
-		allowedSubdomains: "*"
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.bar.example.com", {
-		url: "http://foo.example.com",
-		allowedSubdomains: "*"
-	})).toBe(true)
+	expect(
+		isAllowedUrl("http://example.com/foo", {
+			url: "http://example.com/foo/bar",
+			allowedSubdomains: "*"
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.example.com", {
+			url: "http://example.com",
+			allowedSubdomains: "*"
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.example.com", {
+			url: "http://bar.example.com",
+			allowedSubdomains: "*"
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.bar.example.com", {
+			url: "http://example.com",
+			allowedSubdomains: "*"
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.bar.example.com", {
+			url: "http://foo.example.com",
+			allowedSubdomains: "*"
+		})
+	).toBe(true);
 
-	expect(isAllowedUrl("http://foo.example.com", {
-		url: "http://example.com",
-		allowedSubdomains: ["foo"]
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.example.com", {
-		url: "http://example.com",
-		allowedSubdomains: []
-	})).toBe(false)
-	expect(isAllowedUrl("http://foo.not-allowed.com", {
-		url: "http://example.com",
-		allowedSubdomains: ["foo"]
-	})).toBe(false)
+	expect(
+		isAllowedUrl("http://foo.example.com", {
+			url: "http://example.com",
+			allowedSubdomains: ["foo"]
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.example.com", {
+			url: "http://example.com",
+			allowedSubdomains: []
+		})
+	).toBe(false);
+	expect(
+		isAllowedUrl("http://foo.not-allowed.com", {
+			url: "http://example.com",
+			allowedSubdomains: ["foo"]
+		})
+	).toBe(false);
 
-	expect(isAllowedUrl("http://foo.bar.example.com", {
-		url: "http://example.com",
-		allowedSubdomains: ["foo.bar"]
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.bar.example.com", {
-		url: "http://example.com",
-		allowedSubdomains: ["bar"]
-	})).toBe(false)
+	expect(
+		isAllowedUrl("http://foo.bar.example.com", {
+			url: "http://example.com",
+			allowedSubdomains: ["foo.bar"]
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.bar.example.com", {
+			url: "http://example.com",
+			allowedSubdomains: ["bar"]
+		})
+	).toBe(false);
 
-	expect(isAllowedUrl("http://localhost:3000", {
-		url: "http://localhost:3000",
-		allowedSubdomains: []
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.localhost:3000", {
-		url: "http://localhost:3000",
-		allowedSubdomains: "*"
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.localhost:3000", {
-		url: "http://localhost:3000",
-		allowedSubdomains: ["foo"]
-	})).toBe(true)
-	expect(isAllowedUrl("http://bar.localhost:3000", {
-		url: "http://localhost:3000",
-		allowedSubdomains: ["foo"]
-	})).toBe(false)
+	expect(
+		isAllowedUrl("http://localhost:3000", {
+			url: "http://localhost:3000",
+			allowedSubdomains: []
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.localhost:3000", {
+			url: "http://localhost:3000",
+			allowedSubdomains: "*"
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.localhost:3000", {
+			url: "http://localhost:3000",
+			allowedSubdomains: ["foo"]
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://bar.localhost:3000", {
+			url: "http://localhost:3000",
+			allowedSubdomains: ["foo"]
+		})
+	).toBe(false);
 
-	expect(isAllowedUrl("http://example.", {
-		url: "http://example.",
-		allowedSubdomains: []
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.example.", {
-		url: "http://example.",
-		allowedSubdomains: "*"
-	})).toBe(true)
-	expect(isAllowedUrl("http://foo.example.", {
-		url: "http://example.",
-		allowedSubdomains: ["foo"]
-	})).toBe(true)
-	expect(isAllowedUrl("http://bar.example.", {
-		url: "http://example.",
-		allowedSubdomains: ["foo"]
-	})).toBe(false)
+	expect(
+		isAllowedUrl("http://example.", {
+			url: "http://example.",
+			allowedSubdomains: []
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.example.", {
+			url: "http://example.",
+			allowedSubdomains: "*"
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://foo.example.", {
+			url: "http://example.",
+			allowedSubdomains: ["foo"]
+		})
+	).toBe(true);
+	expect(
+		isAllowedUrl("http://bar.example.", {
+			url: "http://example.",
+			allowedSubdomains: ["foo"]
+		})
+	).toBe(false);
 
-	expect(isAllowedUrl("http://example.com.com", {
-		url: "http://example.com",
-		allowedSubdomains: []
-	})).toBe(false)
-	expect(isAllowedUrl("http://example.com.com", {
-		url: "http://example.com",
-		allowedSubdomains: "*"
-	})).toBe(false)
-	expect(isAllowedUrl("http://localhost.com", {
-		url: "http://localhost:3000",
-		allowedSubdomains: "*"
-	})).toBe(false)
+	expect(
+		isAllowedUrl("http://example.com.com", {
+			url: "http://example.com",
+			allowedSubdomains: []
+		})
+	).toBe(false);
+	expect(
+		isAllowedUrl("http://example.com.com", {
+			url: "http://example.com",
+			allowedSubdomains: "*"
+		})
+	).toBe(false);
+	expect(
+		isAllowedUrl("http://localhost.com", {
+			url: "http://localhost:3000",
+			allowedSubdomains: "*"
+		})
+	).toBe(false);
 });

--- a/packages/lucia/src/utils/url.ts
+++ b/packages/lucia/src/utils/url.ts
@@ -10,8 +10,8 @@ export const isAllowedUrl = (
 		return urlParams.hostname;
 	};
 	const incomingHostname = getHostname(incomingUrl);
-    const appHostname = getHostname(app.url)
-	const appBaseDomain = getBaseDomain(appHostname)
+	const appHostname = getHostname(app.url);
+	const appBaseDomain = getBaseDomain(appHostname);
 	if (incomingHostname === appHostname) return true;
 	if (app.allowedSubdomains === "*") {
 		if (incomingHostname.endsWith(`.${appBaseDomain}`)) return true;
@@ -24,6 +24,6 @@ export const isAllowedUrl = (
 };
 
 const getBaseDomain = (hostname: string) => {
-    if (hostname === "localhost") return "localhost"
-    return hostname.split(".").slice(-2).join(".")
-}
+	if (hostname === "localhost") return "localhost";
+	return hostname.split(".").slice(-2).join(".");
+};

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lucia-auth/oauth
 
+## 2.0.0-beta.6
+
+### Minor changes
+
+- [#814](https://github.com/pilcrowOnPaper/lucia/pull/814) by [@L-Mario564](https://github.com/L-Mario564) : Add osu! OAuth provider
+
+- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.5
 
 ### Patch changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "2.0.0-beta.5",
+	"version": "2.0.0-beta.6",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/src/providers/osu.ts
+++ b/packages/oauth/src/providers/osu.ts
@@ -30,7 +30,7 @@ export const osu = <_Auth extends Auth>(auth: _Auth, config: Config) => {
 			access_token: string;
 			expires_in: number;
 			refresh_token: string;
-      token_type: string;
+			token_type: string;
 		}>(request);
 
 		return {


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### lucia@2.0.0-beta.5
#### Major changes

- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `allowedRequestOrigins` configuration

#### Patch changes

- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `getSessionAndUser()` adapter method getting called when using session adapters
### @lucia-auth/oauth@2.0.0-beta.6
#### Minor changes

- [#814](https://github.com/pilcrowOnPaper/lucia/pull/814) by [@L-Mario564](https://github.com/L-Mario564) : Add osu! OAuth provider

- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-sqlite@2.0.0-beta.6
#### Minor changes

- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Make `session` model name params optional for `betterSqlite3()`, `d1()`, `libsql()`

- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-postgresql@2.0.0-beta.6
#### Minor changes

- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Make `session` model name params optional for `pg()` and `postgres()`

- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-mysql@2.0.0-beta.6
#### Minor changes

- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Make `session` model name params optional for `mysql2()` and `planetscale()`

- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-prisma@3.0.0-beta.5
#### Minor changes

- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Make `session` model name params optional

- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-mongoose@3.0.0-beta.5
#### Minor changes

- [#815](https://github.com/pilcrowOnPaper/lucia/pull/815) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Make `Session` model params optional

- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-session-redis@2.0.0-beta.6
#### Minor changes

- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-test@4.0.0-beta.5
#### Minor changes

- [#812](https://github.com/pilcrowOnPaper/lucia/pull/812) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency