### PR TITLE
the type definition in the docs is incorrect

### DIFF
--- a/documentation/content/main/start-here/getting-started.sveltekit.md
+++ b/documentation/content/main/start-here/getting-started.sveltekit.md
@@ -83,7 +83,7 @@ In `src/app.d.ts`, configure your types. The path in `import('$lib/server/lucia.
 declare global {
 	namespace App {
 		interface Locals {
-			auth: import("lucia").AuthRequest;
+			auth: import("lucia-auth").AuthRequest;
 		}
 	}
 }


### PR DESCRIPTION
the type definition needs to be 

- import ("lucia-auth").AuthRequest so that it matches the `locals.auth.validateUser()` used in the upcoming docs.