### PR TITLE
Update `AuthRequest.validate()` and `AuthRequest.validateBearerToken()` error handling

### DIFF
--- a/.auri/$urcdznnh.md
+++ b/.auri/$urcdznnh.md
@@ -1,0 +1,6 @@
+---
+package: "lucia" # package name
+type: "major" # "major", "minor", "patch"
+---
+
+`AuthRequest.validate()` and `Auth.validateBearerToken()` throws database errors

--- a/documentation-v2/content/main/2.database-adapters/unstorage.md
+++ b/documentation-v2/content/main/2.database-adapters/unstorage.md
@@ -46,7 +46,7 @@ import { lucia } from "lucia";
 import { unstorage } from "@lucia-auth/adapter-session-unstorage";
 import { createStorage } from "unstorage";
 
-const storage = createStorage()
+const storage = createStorage();
 
 const auth = lucia({
 	adapter: {

--- a/examples/express/username-and-password/src/routes/logout.ts
+++ b/examples/express/username-and-password/src/routes/logout.ts
@@ -8,7 +8,7 @@ router.post("/logout", async (req, res) => {
 	const authRequest = auth.handleRequest(req, res);
 	const session = await authRequest.validate();
 	if (!session) {
-		return res.status(401).send(Not authenticated);
+		return res.status(401).send("Not authenticated");
 	}
 	await auth.invalidateSession(session.sessionId);
 	authRequest.setSession(null);

--- a/examples/sveltekit/email-and-password/src/routes/password-reset/[token]/+page.server.ts
+++ b/examples/sveltekit/email-and-password/src/routes/password-reset/[token]/+page.server.ts
@@ -1,9 +1,6 @@
 import { auth } from '$lib/server/lucia';
 import { fail, redirect } from '@sveltejs/kit';
-import {
-	isValidPasswordResetToken,
-	validatePasswordResetToken
-} from '$lib/server/token';
+import { isValidPasswordResetToken, validatePasswordResetToken } from '$lib/server/token';
 
 import type { PageServerLoad, Actions } from './$types';
 

--- a/packages/lucia/src/auth/request.ts
+++ b/packages/lucia/src/auth/request.ts
@@ -2,6 +2,7 @@ import { debug } from "../utils/debug.js";
 
 import type { Auth, Env, Session } from "./index.js";
 import type { Cookie } from "./cookie.js";
+import { LuciaError } from "./error.js";
 
 export type LuciaRequest = {
 	method: string;
@@ -96,7 +97,10 @@ export class AuthRequest<_Auth extends Auth = any> {
 					this.setSessionCookie(session);
 				}
 				return resolve(session);
-			} catch {
+			} catch (e) {
+				if (!(e instanceof LuciaError)) {
+					throw e;
+				}
 				this.setSessionCookie(null);
 				return resolve(null);
 			}
@@ -116,7 +120,10 @@ export class AuthRequest<_Auth extends Auth = any> {
 				const session = await this.auth.getSession(this.bearerToken);
 				if (session.state === "idle") return resolve(null);
 				return resolve(session);
-			} catch {
+			} catch (e) {
+				if (!(e instanceof LuciaError)) {
+					throw e;
+				}
 				return resolve(null);
 			}
 		});

--- a/packages/lucia/src/auth/request.ts
+++ b/packages/lucia/src/auth/request.ts
@@ -98,11 +98,11 @@ export class AuthRequest<_Auth extends Auth = any> {
 				}
 				return resolve(session);
 			} catch (e) {
-				if (!(e instanceof LuciaError)) {
-					throw e;
+				if (e instanceof LuciaError) {
+					this.setSessionCookie(null);
+					return resolve(null);
 				}
-				this.setSessionCookie(null);
-				return resolve(null);
+				throw e;
 			}
 		});
 
@@ -121,10 +121,10 @@ export class AuthRequest<_Auth extends Auth = any> {
 				if (session.state === "idle") return resolve(null);
 				return resolve(session);
 			} catch (e) {
-				if (!(e instanceof LuciaError)) {
-					throw e;
+				if (e instanceof LuciaError) {
+					return resolve(null);
 				}
-				return resolve(null);
+				throw e;
 			}
 		});
 

--- a/packages/lucia/src/auth/session.ts
+++ b/packages/lucia/src/auth/session.ts
@@ -2,6 +2,8 @@ import { isWithinExpiration } from "../utils/date.js";
 
 import type { SessionSchema } from "./database.js";
 
-export const isValidDatabaseSession = (databaseSession: SessionSchema): boolean => {
+export const isValidDatabaseSession = (
+	databaseSession: SessionSchema
+): boolean => {
 	return isWithinExpiration(databaseSession.idle_expires);
 };

--- a/packages/lucia/src/utils/nanoid.ts
+++ b/packages/lucia/src/utils/nanoid.ts
@@ -6,8 +6,7 @@ const getRandomValues = (bytes: number): Uint8Array => {
 	return crypto.getRandomValues(new Uint8Array(bytes));
 };
 
-const DEFAULT_ALPHABET =
-	"abcdefghijklmnopqrstuvwxyz1234567890";
+const DEFAULT_ALPHABET = "abcdefghijklmnopqrstuvwxyz1234567890";
 
 export const generateRandomString = (
 	size: number,


### PR DESCRIPTION
`AuthRequest.validate()` and `AuthRequest.validateBearerToken()` throws non-`LuciaError` errors (ie. database errors)