### PR TITLE
CI: Release

### DIFF
--- a/.auri/$1grcf5gg.md
+++ b/.auri/$1grcf5gg.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mongoose" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$2i2d7c2f.md
+++ b/.auri/$2i2d7c2f.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add `Auth.transformDatabaseUser()`, `Auth.transformDatabaseKey()`, and `Auth.transformDatabaseSession()`

--- a/.auri/$6ta3zpy7.md
+++ b/.auri/$6ta3zpy7.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Export `createKeyId()`

--- a/.auri/$bmyc0k87.md
+++ b/.auri/$bmyc0k87.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mysql" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$fmywhd3l.md
+++ b/.auri/$fmywhd3l.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-User ids and session ids only consist of lowercase letters and numbers by default

--- a/.auri/$g3gkum9c.md
+++ b/.auri/$g3gkum9c.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-postgresql" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$j1zrvzc4.md
+++ b/.auri/$j1zrvzc4.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-prisma" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$txmmm7c5.md
+++ b/.auri/$txmmm7c5.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-session-redis" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$urcdznnh.md
+++ b/.auri/$urcdznnh.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-`AuthRequest.validate()` and `Auth.validateBearerToken()` throws database errors

--- a/.auri/$vhyd6s0y.md
+++ b/.auri/$vhyd6s0y.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-sqlite" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$x6r5u8nf.md
+++ b/.auri/$x6r5u8nf.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-test" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$yimeu9h1.md
+++ b/.auri/$yimeu9h1.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/packages/adapter-mongoose/CHANGELOG.md
+++ b/packages/adapter-mongoose/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-mongoose
 
+## 3.0.0-beta.6
+
+### Minor changes
+
+- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 3.0.0-beta.5
 
 ### Minor changes

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mongoose",
-	"version": "3.0.0-beta.5",
+	"version": "3.0.0-beta.6",
 	"description": "Mongoose (MongoDB) adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-mysql/CHANGELOG.md
+++ b/packages/adapter-mysql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-mysql
 
+## 2.0.0-beta.7
+
+### Minor changes
+
+- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.6
 
 ### Minor changes

--- a/packages/adapter-mysql/package.json
+++ b/packages/adapter-mysql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mysql",
-	"version": "2.0.0-beta.6",
+	"version": "2.0.0-beta.7",
 	"description": "MySQL adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-postgresql/CHANGELOG.md
+++ b/packages/adapter-postgresql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-postgresql
 
+## 2.0.0-beta.7
+
+### Minor changes
+
+- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.6
 
 ### Minor changes

--- a/packages/adapter-postgresql/package.json
+++ b/packages/adapter-postgresql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-postgresql",
-	"version": "2.0.0-beta.6",
+	"version": "2.0.0-beta.7",
 	"description": "PostgreSQL adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-prisma/CHANGELOG.md
+++ b/packages/adapter-prisma/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-prisma
 
+## 3.0.0-beta.7
+
+### Minor changes
+
+- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 3.0.0-beta.6
 
 ### Patch changes

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-prisma",
-	"version": "3.0.0-beta.6",
+	"version": "3.0.0-beta.7",
 	"description": "Prisma adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-session-redis/CHANGELOG.md
+++ b/packages/adapter-session-redis/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-session-redis
 
+## 2.0.0-beta.7
+
+### Minor changes
+
+- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.6
 
 ### Minor changes

--- a/packages/adapter-session-redis/package.json
+++ b/packages/adapter-session-redis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-session-redis",
-	"version": "2.0.0-beta.6",
+	"version": "2.0.0-beta.7",
 	"description": "Redis session adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-sqlite/CHANGELOG.md
+++ b/packages/adapter-sqlite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-sqlite
 
+## 2.0.0-beta.7
+
+### Minor changes
+
+- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.6
 
 ### Minor changes

--- a/packages/adapter-sqlite/package.json
+++ b/packages/adapter-sqlite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-sqlite",
-	"version": "2.0.0-beta.6",
+	"version": "2.0.0-beta.7",
 	"description": "SQLite adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-test/CHANGELOG.md
+++ b/packages/adapter-test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-test
 
+## 4.0.0-beta.6
+
+### Minor changes
+
+- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 4.0.0-beta.5
 
 ### Minor changes

--- a/packages/adapter-test/package.json
+++ b/packages/adapter-test/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-test",
-	"version": "4.0.0-beta.5",
+	"version": "4.0.0-beta.6",
 	"description": "Testing module for Lucia database adapters",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/lucia/CHANGELOG.md
+++ b/packages/lucia/CHANGELOG.md
@@ -1,5 +1,19 @@
 # lucia
 
+## 2.0.0-beta.6
+
+### Major changes
+
+- [#836](https://github.com/pilcrowOnPaper/lucia/pull/836) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : User ids and session ids only consist of lowercase letters and numbers by default
+
+- [#839](https://github.com/pilcrowOnPaper/lucia/pull/839) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : `AuthRequest.validate()` and `Auth.validateBearerToken()` throws database errors
+
+### Minor changes
+
+- [#838](https://github.com/pilcrowOnPaper/lucia/pull/838) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `Auth.transformDatabaseUser()`, `Auth.transformDatabaseKey()`, and `Auth.transformDatabaseSession()`
+
+- [#838](https://github.com/pilcrowOnPaper/lucia/pull/838) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Export `createKeyId()`
+
 ## 2.0.0-beta.5
 
 ### Major changes

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia",
-	"version": "2.0.0-beta.5",
+	"version": "2.0.0-beta.6",
 	"description": "A simple and flexible authentication library",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/oauth
 
+## 2.0.0-beta.7
+
+### Minor changes
+
+- [#843](https://github.com/pilcrowOnPaper/lucia/pull/843) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.6
 
 ### Minor changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "2.0.0-beta.6",
+	"version": "2.0.0-beta.7",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/adapter-mongoose@3.0.0-beta.6
#### Minor changes

- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### lucia@2.0.0-beta.6
#### Major changes

- [#836](https://github.com/pilcrowOnPaper/lucia/pull/836) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : User ids and session ids only consist of lowercase letters and numbers by default

- [#839](https://github.com/pilcrowOnPaper/lucia/pull/839) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : `AuthRequest.validate()` and `Auth.validateBearerToken()` throws database errors

#### Minor changes

- [#838](https://github.com/pilcrowOnPaper/lucia/pull/838) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `Auth.transformDatabaseUser()`, `Auth.transformDatabaseKey()`, and `Auth.transformDatabaseSession()`

- [#838](https://github.com/pilcrowOnPaper/lucia/pull/838) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Export `createKeyId()`
### @lucia-auth/adapter-mysql@2.0.0-beta.7
#### Minor changes

- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-postgresql@2.0.0-beta.7
#### Minor changes

- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-prisma@3.0.0-beta.7
#### Minor changes

- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-session-redis@2.0.0-beta.7
#### Minor changes

- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-sqlite@2.0.0-beta.7
#### Minor changes

- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-test@4.0.0-beta.6
#### Minor changes

- [#842](https://github.com/pilcrowOnPaper/lucia/pull/842) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/oauth@2.0.0-beta.7
#### Minor changes

- [#843](https://github.com/pilcrowOnPaper/lucia/pull/843) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency