### PR TITLE
CI: Release

### DIFF
--- a/.auri/$1xxt97n5.md
+++ b/.auri/$1xxt97n5.md
@@ -1,7 +1,0 @@
----
-package: "lucia" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Export `generateLuciaPasswordHash`, `validateLuciaPasswordHash` from `/utils`
-

--- a/.auri/$6hmprern.md
+++ b/.auri/$6hmprern.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-sqlite" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Require `@libsql/client@0.3.0`

--- a/.auri/$6o51jkq8.md
+++ b/.auri/$6o51jkq8.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Remove Node dependent type check

--- a/.auri/$8h9k9jzr.md
+++ b/.auri/$8h9k9jzr.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-prisma" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Update `prisma()` params

--- a/.auri/$ftny8ufw.md
+++ b/.auri/$ftny8ufw.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Normalize string before comparing when validating hashes

--- a/.auri/$g2iakqql.md
+++ b/.auri/$g2iakqql.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Rename `cookieName` to `sessionCookieName` in `Middleware`

--- a/.auri/$gehg0gxs.md
+++ b/.auri/$gehg0gxs.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-sqlite" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Remove `@libsql/client` import

--- a/.auri/$nsc3vyf1.md
+++ b/.auri/$nsc3vyf1.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-postgresql" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$nsc3vyf2.md
+++ b/.auri/$nsc3vyf2.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mysql" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$nsc3vyf3.md
+++ b/.auri/$nsc3vyf3.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-prisma" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$nsc3vyf4.md
+++ b/.auri/$nsc3vyf4.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-session-redis" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$nsc3vyf5.md
+++ b/.auri/$nsc3vyf5.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-session-unstorage" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$nsc3vyf6.md
+++ b/.auri/$nsc3vyf6.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-sqlite" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$nsc3vyf7.md
+++ b/.auri/$nsc3vyf7.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-test" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$nsc3vyf8.md
+++ b/.auri/$nsc3vyf8.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$nsc3vyfx.md
+++ b/.auri/$nsc3vyfx.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mongoose" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update peer dependency

--- a/.auri/$v6vvafbw.md
+++ b/.auri/$v6vvafbw.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-session-unstorage" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-use correct exports in package.json, fixes #861

--- a/.auri/$woxsf5uf.md
+++ b/.auri/$woxsf5uf.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-mysql" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Update `planetscale()` adapter types

--- a/documentation-v2/content/guidebook/sign-in-with-username-and-password/nextjs-app.md
+++ b/documentation-v2/content/guidebook/sign-in-with-username-and-password/nextjs-app.md
@@ -408,7 +408,11 @@ export const POST = async (request: NextRequest) => {
 	try {
 		// find user by key
 		// and validate password
-		const user = await auth.useKey("username", username.toLowerCase(), password);
+		const user = await auth.useKey(
+			"username",
+			username.toLowerCase(),
+			password
+		);
 		const session = await auth.createSession({
 			userId: user.userId,
 			attributes: {}

--- a/packages/adapter-mongoose/CHANGELOG.md
+++ b/packages/adapter-mongoose/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-mongoose
 
+## 3.0.0-beta.7
+
+### Minor changes
+
+- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 3.0.0-beta.6
 
 ### Minor changes

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mongoose",
-	"version": "3.0.0-beta.6",
+	"version": "3.0.0-beta.7",
 	"description": "Mongoose (MongoDB) adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-mysql/CHANGELOG.md
+++ b/packages/adapter-mysql/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @lucia-auth/adapter-mysql
 
+## 2.0.0-beta.8
+
+### Minor changes
+
+- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
+### Patch changes
+
+- [#859](https://github.com/pilcrowOnPaper/lucia/pull/859) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `planetscale()` adapter types
+
 ## 2.0.0-beta.7
 
 ### Minor changes

--- a/packages/adapter-mysql/package.json
+++ b/packages/adapter-mysql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mysql",
-	"version": "2.0.0-beta.7",
+	"version": "2.0.0-beta.8",
 	"description": "MySQL adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-postgresql/CHANGELOG.md
+++ b/packages/adapter-postgresql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-postgresql
 
+## 2.0.0-beta.8
+
+### Minor changes
+
+- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.7
 
 ### Minor changes

--- a/packages/adapter-postgresql/package.json
+++ b/packages/adapter-postgresql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-postgresql",
-	"version": "2.0.0-beta.7",
+	"version": "2.0.0-beta.8",
 	"description": "PostgreSQL adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-prisma/CHANGELOG.md
+++ b/packages/adapter-prisma/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @lucia-auth/adapter-prisma
 
+## 3.0.0-beta.8
+
+### Major changes
+
+- [#858](https://github.com/pilcrowOnPaper/lucia/pull/858) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `prisma()` params
+
+### Minor changes
+
+- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 3.0.0-beta.7
 
 ### Minor changes

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-prisma",
-	"version": "3.0.0-beta.7",
+	"version": "3.0.0-beta.8",
 	"description": "Prisma adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-prisma/src/prisma.ts
+++ b/packages/adapter-prisma/src/prisma.ts
@@ -35,9 +35,7 @@ export const prismaAdapter = <_PrismaClient extends PrismaClient>(
 		return {
 			User: client[modelNames.user] as SmartPrismaModel<UserSchema>,
 			Session: modelNames.session
-				? (client[
-						modelNames.session
-				  ] as SmartPrismaModel<SessionSchema>)
+				? (client[modelNames.session] as SmartPrismaModel<SessionSchema>)
 				: null,
 			Key: client[modelNames.key] as SmartPrismaModel<KeySchema>
 		};

--- a/packages/adapter-session-redis/CHANGELOG.md
+++ b/packages/adapter-session-redis/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-session-redis
 
+## 2.0.0-beta.8
+
+### Minor changes
+
+- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.7
 
 ### Minor changes

--- a/packages/adapter-session-redis/package.json
+++ b/packages/adapter-session-redis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-session-redis",
-	"version": "2.0.0-beta.7",
+	"version": "2.0.0-beta.8",
 	"description": "Redis session adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-session-unstorage/CHANGELOG.md
+++ b/packages/adapter-session-unstorage/CHANGELOG.md
@@ -1,1 +1,11 @@
 # @lucia-auth/adapter-session-unstorage
+
+## 2.0.0-beta.1
+
+### Minor changes
+
+- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
+### Patch changes
+
+- [#862](https://github.com/pilcrowOnPaper/lucia/pull/862) by [@schweden1997](https://github.com/schweden1997) : use correct exports in package.json, fixes #861

--- a/packages/adapter-session-unstorage/package.json
+++ b/packages/adapter-session-unstorage/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-session-unstorage",
-	"version": "2.0.0-beta.0",
+	"version": "2.0.0-beta.1",
 	"description": "Unstorage session adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-sqlite/CHANGELOG.md
+++ b/packages/adapter-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @lucia-auth/adapter-sqlite
 
+## 2.0.0-beta.8
+
+### Major changes
+
+- [#822](https://github.com/pilcrowOnPaper/lucia/pull/822) by [@abdel-17](https://github.com/abdel-17) : Require `@libsql/client@0.3.0`
+
+### Minor changes
+
+- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
+### Patch changes
+
+- [#846](https://github.com/pilcrowOnPaper/lucia/pull/846) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `@libsql/client` import
+
 ## 2.0.0-beta.7
 
 ### Minor changes

--- a/packages/adapter-sqlite/package.json
+++ b/packages/adapter-sqlite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-sqlite",
-	"version": "2.0.0-beta.7",
+	"version": "2.0.0-beta.8",
 	"description": "SQLite adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/adapter-test/CHANGELOG.md
+++ b/packages/adapter-test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-test
 
+## 4.0.0-beta.7
+
+### Minor changes
+
+- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 4.0.0-beta.6
 
 ### Minor changes

--- a/packages/adapter-test/package.json
+++ b/packages/adapter-test/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-test",
-	"version": "4.0.0-beta.6",
+	"version": "4.0.0-beta.7",
 	"description": "Testing module for Lucia database adapters",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/lucia/CHANGELOG.md
+++ b/packages/lucia/CHANGELOG.md
@@ -1,5 +1,21 @@
 # lucia
 
+## 2.0.0-beta.7
+
+### Major changes
+
+- [#866](https://github.com/pilcrowOnPaper/lucia/pull/866) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Rename `cookieName` to `sessionCookieName` in `Middleware`
+
+### Minor changes
+
+- [#864](https://github.com/pilcrowOnPaper/lucia/pull/864) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Export `generateLuciaPasswordHash`, `validateLuciaPasswordHash` from `/utils`
+
+### Patch changes
+
+- [#849](https://github.com/pilcrowOnPaper/lucia/pull/849) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove Node dependent type check
+
+- [#848](https://github.com/pilcrowOnPaper/lucia/pull/848) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Normalize string before comparing when validating hashes
+
 ## 2.0.0-beta.6
 
 ### Major changes

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia",
-	"version": "2.0.0-beta.6",
+	"version": "2.0.0-beta.7",
 	"description": "A simple and flexible authentication library",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/oauth
 
+## 2.0.0-beta.8
+
+### Minor changes
+
+- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
+
 ## 2.0.0-beta.7
 
 ### Minor changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "2.0.0-beta.7",
+	"version": "2.0.0-beta.8",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### lucia@2.0.0-beta.7
#### Major changes

- [#866](https://github.com/pilcrowOnPaper/lucia/pull/866) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Rename `cookieName` to `sessionCookieName` in `Middleware`

#### Minor changes

- [#864](https://github.com/pilcrowOnPaper/lucia/pull/864) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Export `generateLuciaPasswordHash`, `validateLuciaPasswordHash` from `/utils`

#### Patch changes

- [#849](https://github.com/pilcrowOnPaper/lucia/pull/849) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove Node dependent type check

- [#848](https://github.com/pilcrowOnPaper/lucia/pull/848) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Normalize string before comparing when validating hashes
### @lucia-auth/adapter-sqlite@2.0.0-beta.8
#### Major changes

- [#822](https://github.com/pilcrowOnPaper/lucia/pull/822) by [@abdel-17](https://github.com/abdel-17) : Require `@libsql/client@0.3.0`

#### Minor changes

- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency

#### Patch changes

- [#846](https://github.com/pilcrowOnPaper/lucia/pull/846) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `@libsql/client` import
### @lucia-auth/adapter-prisma@3.0.0-beta.8
#### Major changes

- [#858](https://github.com/pilcrowOnPaper/lucia/pull/858) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `prisma()` params

#### Minor changes

- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-postgresql@2.0.0-beta.8
#### Minor changes

- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-mysql@2.0.0-beta.8
#### Minor changes

- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency

#### Patch changes

- [#859](https://github.com/pilcrowOnPaper/lucia/pull/859) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `planetscale()` adapter types
### @lucia-auth/adapter-session-redis@2.0.0-beta.8
#### Minor changes

- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-session-unstorage@2.0.0-beta.1
#### Minor changes

- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency

#### Patch changes

- [#862](https://github.com/pilcrowOnPaper/lucia/pull/862) by [@schweden1997](https://github.com/schweden1997) : use correct exports in package.json, fixes #861
### @lucia-auth/adapter-test@4.0.0-beta.7
#### Minor changes

- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/oauth@2.0.0-beta.8
#### Minor changes

- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency
### @lucia-auth/adapter-mongoose@3.0.0-beta.7
#### Minor changes

- [#867](https://github.com/pilcrowOnPaper/lucia/pull/867) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update peer dependency