### PR TITLE
Add getSessionAndUserBySessionId method to adapter-mongoose

### DIFF
--- a/.auri/$ftuu9etk.md
+++ b/.auri/$ftuu9etk.md
@@ -3,4 +3,4 @@ package: "@lucia-auth/adapter-mongoose" # package name
 type: "minor" # "major", "minor", "patch"
 ---
 
-Add a getSessionAndUserBySessionId method to adapter-mongoose, using a lookup (join) instead of two separate db calls.
+Add a `getSessionAndUserBySessionId` method to `mongoose()` adapter, using a lookup (join) instead of two separate db calls.

--- a/.auri/$ftuu9etk.md
+++ b/.auri/$ftuu9etk.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/adapter-mongoose" # package name
+type: "minor" # "major", "minor", "patch"
+---
+
+Add a getSessionAndUserBySessionId method to adapter-mongoose, using a lookup (join) instead of two separate db calls.

--- a/packages/adapter-mongoose/src/mongoose.ts
+++ b/packages/adapter-mongoose/src/mongoose.ts
@@ -1,12 +1,12 @@
-import type { Model } from "mongoose";
 import type {
 	Adapter,
 	InitializeAdapter,
 	KeySchema,
-	UserSchema,
-	SessionSchema
+	SessionSchema,
+	UserSchema
 } from "lucia";
-import type { UserDoc, SessionDoc, KeyDoc } from "./docs.js";
+import type { Model } from "mongoose";
+import type { KeyDoc, SessionDoc, UserDoc } from "./docs.js";
 
 export const DEFAULT_PROJECTION = {
 	$__: 0,
@@ -97,7 +97,7 @@ export const mongooseAdapter = (models: {
 							// Relies on _id being a String, not ObjectId. 
 							// But this assumption is used elsewhere, as well
 							foreignField: "_id",
-							as: "users"
+							as: "userDocs"
 						}
 					}
 				]).exec();
@@ -105,7 +105,7 @@ export const mongooseAdapter = (models: {
 				const sessionUser = sessionUsers?.at(0) ?? null;
 				if (!sessionUser) return null
 
-				const { users: userDocs, ...sessionDoc } = sessionUser;
+				const { userDocs, ...sessionDoc } = sessionUser;
 				const userDoc = userDocs?.at(0) ?? null;
 				if (!userDoc) return null;
 

--- a/packages/adapter-mongoose/src/mongoose.ts
+++ b/packages/adapter-mongoose/src/mongoose.ts
@@ -88,7 +88,7 @@ export const mongooseAdapter = (models: {
 					throw new Error("Session model not defined");
 				}
 
-				const sessionUser = await Session.aggregate([
+				const sessionUsers = await Session.aggregate([
 					{ $match: { _id: sessionId } },
 					{
 						$lookup: {
@@ -102,22 +102,16 @@ export const mongooseAdapter = (models: {
 					}
 				]).exec();
 
-				// More verbose, if you prefer:
-				// if (
-				//     !sessionUser || 
-				//     !sessionUser[0] ||
-				//     !sessionUser[0].users ||
-				//     !sessionUser[0].users[0]
-				// ) return null
+				const sessionUser = sessionUsers?.at(0) ?? null;
+				if (!sessionUser) return null
 
-				if (!sessionUser?.[0]?.users?.length) return null;
-
-				const { users, ...session } = sessionUser[0];
-
+				const { users: userDocs, ...sessionDoc } = sessionUser;
+				const userDoc = userDocs?.at(0) ?? null;
+				if (!userDoc) return null;
 
 				return {
-					user: transformUserDoc(users[0]),
-					session: transformSessionDoc(session)
+					user: transformUserDoc(userDoc),
+					session: transformSessionDoc(sessionDoc)
 				};
 			},
 			setSession: async (session) => {


### PR DESCRIPTION
As discussed on Discord.
I've added a `getSessionAndUserBySessionId` method to the mongoose adapter, which uses a lookup (join) instead of two separate db calls.