### PR TITLE
updated drizzle sqlite docs

### DIFF
--- a/documentation/content/guidebook/drizzle-orm/index.md
+++ b/documentation/content/guidebook/drizzle-orm/index.md
@@ -255,44 +255,44 @@ Make sure to change the table names accordingly.
 
 ```ts
 // schema.js
-import { pgTable, bigint, varchar, boolean } from "drizzle-orm/pg-core";
+import { sqliteTable, text, blob } from "drizzle-orm/sqlite-core";
 
-export const user = pgTable("user", {
-	id: varchar("id", {
-		length: 15 // change this when using custom user ids
-	}).primaryKey()
-	// other user attributes
+export const user = sqliteTable("user", {
+  id: text("id", {
+    length: 15, // change this when using custom user ids
+  }).primaryKey(),
+  // other user attributes
 });
 
-export const session = pgTable("user_session", {
-	id: varchar("id", {
-		length: 128
-	}).primaryKey(),
-	userId: varchar("user_id", {
-		length: 15
-	})
-		.notNull()
-		.references(() => user.id),
-	activeExpires: bigint("active_expires", {
-		mode: "number"
-	}).notNull(),
-	idleExpires: bigint("idle_expires", {
-		mode: "number"
-	}).notNull()
+export const session = sqliteTable("user_session", {
+  id: text("id", {
+    length: 128,
+  }).primaryKey(),
+  userId: text("user_id", {
+    length: 15,
+  })
+    .notNull()
+    .references(() => user.id),
+  activeExpires: blob("active_expires", {
+    mode: "bigint",
+  }).notNull(),
+  idleExpires: blob("idle_expires", {
+    mode: "bigint",
+  }).notNull(),
 });
 
-export const key = pgTable("user_key", {
-	id: varchar("id", {
-		length: 255
-	}).primaryKey(),
-	userId: varchar("user_id", {
-		length: 15
-	})
-		.notNull()
-		.references(() => user.id),
-	hashedPassword: varchar("hashed_password", {
-		length: 255
-	})
+export const key = sqliteTable("user_key", {
+  id: text("id", {
+    length: 255,
+  }).primaryKey(),
+  userId: text("user_id", {
+    length: 15,
+  })
+    .notNull()
+    .references(() => user.id),
+  hashedPassword: text("hashed_password", {
+    length: 255,
+  }),
 });
 ```
 

--- a/documentation/content/guidebook/drizzle-orm/index.md
+++ b/documentation/content/guidebook/drizzle-orm/index.md
@@ -264,9 +264,7 @@ export const user = sqliteTable("user", {
 
 export const session = sqliteTable("user_session", {
   id: text("id").primaryKey(),
-  userId: text("user_id", {
-    length: 15,
-  })
+  userId: text("user_id")
     .notNull()
     .references(() => user.id),
   activeExpires: blob("active_expires", {
@@ -279,14 +277,10 @@ export const session = sqliteTable("user_session", {
 
 export const key = sqliteTable("user_key", {
   id: text("id").primaryKey(),
-  userId: text("user_id", {
-    length: 15,
-  })
+  userId: text("user_id")
     .notNull()
     .references(() => user.id),
-  hashedPassword: text("hashed_password", {
-    length: 255,
-  }),
+  hashedPassword: text("hashed_password"),
 });
 ```
 

--- a/documentation/content/guidebook/drizzle-orm/index.md
+++ b/documentation/content/guidebook/drizzle-orm/index.md
@@ -258,16 +258,12 @@ Make sure to change the table names accordingly.
 import { sqliteTable, text, blob } from "drizzle-orm/sqlite-core";
 
 export const user = sqliteTable("user", {
-  id: text("id", {
-    length: 15, // change this when using custom user ids
-  }).primaryKey(),
+  id: text("id").primaryKey(),
   // other user attributes
 });
 
 export const session = sqliteTable("user_session", {
-  id: text("id", {
-    length: 128,
-  }).primaryKey(),
+  id: text("id").primaryKey(),
   userId: text("user_id", {
     length: 15,
   })
@@ -282,9 +278,7 @@ export const session = sqliteTable("user_session", {
 });
 
 export const key = sqliteTable("user_key", {
-  id: text("id", {
-    length: 255,
-  }).primaryKey(),
+  id: text("id").primaryKey(),
   userId: text("user_id", {
     length: 15,
   })


### PR DESCRIPTION
The Drizzle ORM Documentation was using `pgTable` for `sqlite`
Updated `pgTable` to `sqliteTable`

- [there is no bigint data type in SQLite](https://orm.drizzle.team/docs/column-types/sqlite#bigint) so used `blob` with `mode`
- convert `varchar` to `text`