### PR TITLE
fix authorization url function

### DIFF
--- a/packages/oauth/src/core.ts
+++ b/packages/oauth/src/core.ts
@@ -108,7 +108,7 @@ export const createOAuth2AuthorizationUrl = async (
 		client_id: options.clientId,
 		scope: options.scope.join(" "),
 		state: options.state ?? state,
-		redirect_url: options.redirectUri,
+		redirect_uri: options.redirectUri,
 		...searchParams
 	});
 	return [authorizationUrl, state] as const;


### PR DESCRIPTION
Change `createOAuth2AuthorizationUrl` to use `redirect_uri` instead of `redirect_url` (fixes #936)