### PR TITLE
Github now fetches email address by default

### DIFF
--- a/.auri/$xdz7arqy.md
+++ b/.auri/$xdz7arqy.md
@@ -1,0 +1,12 @@
+---
+package: "@lucia-auth/oauth" # package name
+type: "minor" # "major", "minor", "patch"
+---
+
+Github oAuth provider doesn't return an email by default. Email can be null.
+
+My code fetches the primary email from the user's Github profile. This way, we don't have to return null for a Github profile.
+
+This is also now a thing in Next-Auth. See this issue: https://github.com/nextauthjs/next-auth/issues/374
+
+My code is a replication straight from the next-auth library's Github oAuth part. See: https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/github.ts#L80


### PR DESCRIPTION
When I tried using the Github oauth provider, I didn't get the user's email when a new user would sign up. This is because by default Github doesn't give you the user's email address. However, you can get the email address from a separate API request.

This is an issue that was also present with Next-Auth. See: https://github.com/nextauthjs/next-auth/issues/374

Their Github oAuth provider now always returns an email address as noted at the bottom of their documentation page. See: https://next-auth.js.org/providers/github

My pull request adds a very basic code snippet and a type called GithubEmail to the Github provider. This way, the provider automatically fetches and returns the email of the user. I've tested it, and it works in my project!

The code I've added is a replication straight from the next-auth implementation of the same.

I think the Github oauth provider should always return an email address because most websites/apps don't have a username, and use email for all communication.

This is my first pull request to Lucia. Let me know if I'm doing anything wrong! :)