### PR TITLE
CI: Release

### DIFF
--- a/.auri/$0v6bujvp.md
+++ b/.auri/$0v6bujvp.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix `createOAuth2AuthorizationUrl()` and `createOAuth2AuthorizationUrlWithPKCE()` incorrectly setting `redirect_uri` field to `redirect_url`.

--- a/.auri/$nel64i27.md
+++ b/.auri/$nel64i27.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add `hono()` middleware

--- a/packages/lucia/CHANGELOG.md
+++ b/packages/lucia/CHANGELOG.md
@@ -1,5 +1,11 @@
 # lucia
 
+## 2.2.0
+
+### Minor changes
+
+- [#944](https://github.com/pilcrowOnPaper/lucia/pull/944) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `hono()` middleware
+
 ## 2.1.0
 
 ### Minor changes

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "A simple and flexible authentication library",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/oauth
 
+## 2.1.1
+
+### Patch changes
+
+- [#948](https://github.com/pilcrowOnPaper/lucia/pull/948) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `createOAuth2AuthorizationUrl()` and `createOAuth2AuthorizationUrlWithPKCE()` incorrectly setting `redirect_uri` field to `redirect_url`.
+
 ## 2.1.0
 
 ### Minor changes
@@ -7,9 +13,13 @@
 - [#910](https://github.com/pilcrowOnPaper/lucia/pull/910) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add experimental OAuth helpers:
 
   - `createOAuth2AuthorizationUrl()`
+
   - `createOAuth2AuthorizationUrlWithPKCE()`
+
   - `validateOAuth2AuthorizationCode()`
+
   - `decodeIdToken()`
+
   - `IdTokenError`
 
 - [#657](https://github.com/pilcrowOnPaper/lucia/pull/657) by [@luccasr73](https://github.com/luccasr73) : Add Apple provider

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/oauth@2.1.1
#### Patch changes

- [#948](https://github.com/pilcrowOnPaper/lucia/pull/948) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `createOAuth2AuthorizationUrl()` and `createOAuth2AuthorizationUrlWithPKCE()` incorrectly setting `redirect_uri` field to `redirect_url`.
### lucia@2.2.0
#### Minor changes

- [#944](https://github.com/pilcrowOnPaper/lucia/pull/944) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `hono()` middleware