### PR TITLE
feat: support for fastify middleware

### DIFF
--- a/.auri/$nziehqul.md
+++ b/.auri/$nziehqul.md
@@ -1,0 +1,6 @@
+---
+package: "lucia"
+type: "minor"
+---
+
+Add middleware support for fastify

--- a/.auri/$nziehqul.md
+++ b/.auri/$nziehqul.md
@@ -3,4 +3,4 @@ package: "lucia"
 type: "minor"
 ---
 
-Add middleware support for fastify
+Add `fastify()` middleware

--- a/documentation/content/main/0.start-here/0.getting-started/fastify.md
+++ b/documentation/content/main/0.start-here/0.getting-started/fastify.md
@@ -1,0 +1,143 @@
+---
+title: "Getting started in Fastify"
+menuTitle: "Fastify"
+description: "Learn how to set up Lucia in your Fastify project"
+---
+
+Install Lucia using your package manager of your choice.
+
+```
+npm i lucia
+pnpm add lucia
+yarn add lucia
+```
+
+### ESM
+
+Lucia can only be used in ESM projects. Configure your `package.json` and `tsconfig.json` accordingly.
+
+```json
+// package.json
+{
+	"type": "module"
+	// ...
+}
+```
+
+```json
+// tsconfig.json
+{
+	"compilerOptions": {
+		"module": "ESNext", // "ES2022" etc
+		"moduleResolution": "NodeNext" // "Node", "Node16"
+		// ...
+	}
+	// ...
+}
+```
+
+## Initialize Lucia
+
+Import [`lucia()`](/reference/lucia/main#lucia) from `lucia` and initialize it. Export `auth` and its type as `Auth`. Make sure to pass the `fastify()` middleware We also need to provide an `adapter` but since it'll be specific to the database you're using, we'll cover that later.
+
+```ts
+// lucia.ts
+import { lucia } from "lucia";
+import { fastify } from "lucia/middleware";
+
+// expect error
+export const auth = lucia({
+	env: "DEV", // "PROD" if deployed to HTTPS
+	middleware: fastify()
+});
+
+export type Auth = typeof auth;
+```
+
+## Setup your database
+
+Lucia uses adapters to connect to your database. We provide official adapters for a wide range of database options, but you can always [create your own](/extending-lucia/database-adapters-api). The schema and usage are described in each adapter's documentation. The example below is for the Prisma adapter.
+
+```ts
+import { lucia } from "lucia";
+import { fastify } from "lucia/middleware";
+import { prisma } from "@lucia-auth/adapter-prisma";
+import { PrismaClient } from "@prisma/client";
+
+const client = new PrismaClient();
+
+const auth = lucia({
+	env: "DEV", // "PROD" if deployed to HTTPS
+	middleware: fastify(),
+	adapter: prisma(client)
+});
+```
+
+### Adapters for database drivers and ORMs
+
+- [`better-sqlite3`](/database-adapters/better-sqlite3): SQLite
+- [libSQL](/database-adapters/libsql): libSQL (Turso)
+- [Mongoose](/database-adapters/mongoose): MongoDB
+- [`mysql2`](/database-adapters/mysql2): MySQL
+- [`pg`](/database-adapters/pg): PostgreSQL
+- [`postgres`](/database-adapters/postgres): PostgreSQL
+- [Prisma](/database-adapters/prisma): MongoDB, MySQL, PostgreSQL, SQLite
+- [Redis](/database-adapters/redis): Redis
+- [Unstorage](/database-adapters/unstorage): Azure, Cloudflare KV, Memory, MongoDB, Planetscale, Redis, Vercel KV
+
+### Provider specific adapters
+
+- [Cloudflare D1](/database-adapters/cloudflare-d1)
+- [PlanetScale serverless](/database-adapters/planetscale-serverless)
+- [Upstash Redis](/database-adapters/upstash-redis)
+
+### Using query builders
+
+- [Drizzle ORM](/guidebook/drizzle-orm)
+- [Kysely](/guidebook/kysely)
+
+## Set up types
+
+Create a `.d.ts` file and declare a `Lucia` namespace. The import path for `Auth` is where you initialized `lucia()`.
+
+```ts
+// app.d.ts
+/// <reference types="lucia" />
+declare namespace Lucia {
+	type Auth = import("./lucia.js").Auth;
+	type DatabaseUserAttributes = {};
+	type DatabaseSessionAttributes = {};
+}
+```
+
+## Polyfill
+
+If you're using Node.js version 18 or below, you need to polyfill the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API).
+
+```ts
+import { lucia } from "lucia";
+import "lucia/polyfill/node";
+
+export const auth = lucia({
+	// ...
+});
+```
+
+Optionally, instead of doing a side-effect import, add the `--experimental-global-webcrypto` flag when running `fastify`.
+
+```json
+{
+	"scripts": {
+		"start": "NODE_OPTIONS=--experimental-global-webcrypto fastify start -l info app.js",
+		"dev": "NODE_OPTIONS=--experimental-global-webcrypto npm run build && fastify start -w -l info -P app.js"
+		// ...
+	}
+	// ...
+}
+```
+
+## Next steps
+
+You can learn all the concepts and general APIs of Lucia by reading the [Basics](/basics/database) section in the docs. If you prefer writing code immediately, check out the [Starter guides](/start-here/starter-guides) page or the [examples in the repository](https://github.com/pilcrowOnPaper/lucia/tree/main/examples).
+
+Remember to check out the [Guidebook](/guidebook) for tutorials and guides!

--- a/documentation/content/main/0.start-here/0.getting-started/nuxt.md
+++ b/documentation/content/main/0.start-here/0.getting-started/nuxt.md
@@ -19,7 +19,7 @@ Import [`lucia()`](/reference/lucia/main#lucia) from `lucia` and initialize it i
 ```ts
 // server/utils/lucia.ts
 import { lucia } from "lucia";
-import { h3 } from "lucia-auth/middleware";
+import { h3 } from "lucia/middleware";
 
 // expect error
 export const auth = lucia({

--- a/documentation/content/main/0.start-here/0.getting-started/remix.md
+++ b/documentation/content/main/0.start-here/0.getting-started/remix.md
@@ -42,7 +42,7 @@ Make sure to set [`sessionCookie.expires`](/basics/configuration#sessioncookie) 
 ```ts
 // auth/lucia.server.ts
 import { lucia } from "lucia";
-import { web } from "lucia-auth/middleware";
+import { web } from "lucia/middleware";
 
 // expect error
 export const auth = lucia({

--- a/documentation/content/main/1.basics/5.handle-requests.md
+++ b/documentation/content/main/1.basics/5.handle-requests.md
@@ -34,6 +34,7 @@ auth.handleRequest(new Request());
 
 - [Astro](#astro)
 - [Express](#express)
+- [Fastify](#fastify)
 - [H3](#h3)
   - [Nuxt](#nuxt)
 - [Next.js](#nextjs)
@@ -73,6 +74,30 @@ export const get = async (context) => {
 
 We recommend storing `AuthRequest` in `locals`.
 
+### Express
+
+```ts
+import { express } from "lucia/middleware";
+```
+
+```ts
+app.get("/", (req, res) => {
+	const authRequest = auth.handleRequest(req, res);
+});
+```
+
+### Fastify
+
+```ts
+import { fastify } from "lucia/middleware";
+```
+
+```ts
+server.get("/"(request, reply) => {
+	const authRequest = auth.handleRequest(request, reply);
+});
+```
+
 ### H3
 
 ```ts
@@ -86,19 +111,6 @@ import { h3 } from "lucia/middleware";
 export default defineEventHandler(async (event) => {
 	auth.handleRequest(event);
 	// ...
-});
-```
-
-### Express
-
-```ts
-import { express } from "lucia/middleware";
-```
-
-```ts
-app.use((req, res, next) => {
-	res.locals.auth = auth.handleRequest(req, res);
-	next();
 });
 ```
 
@@ -189,7 +201,9 @@ export const middleware = async (request: NextRequest) => {
 
 ```ts
 import { node } from "lucia/middleware";
+```
 
+```ts
 auth.handleRequest(incomingMessage, outgoingMessage);
 ```
 

--- a/documentation/content/reference/lucia/2.middleware.md
+++ b/documentation/content/reference/lucia/2.middleware.md
@@ -22,7 +22,7 @@ auth.handleRequest(context as APIContext);
 | `context` | [`APIContext`](https://docs.astro.build/en/reference/api-reference/#endpoint-context)`\|`[`Astro`](https://docs.astro.build/en/reference/api-reference/#astro-global) |
 
 ```ts
-import { astro } from "lucia-auth/middleware";
+import { astro } from "lucia/middleware";
 
 const auth = lucia({
 	middleware: astro()
@@ -41,7 +41,7 @@ const express: () => Middleware;
 #### Usage
 
 ```ts
-import { express } from "lucia-auth/middleware";
+import { express } from "lucia/middleware";
 
 const auth = lucia({
 	middleware: express()
@@ -58,6 +58,61 @@ auth.handleRequest(request as Request, response as Response);
 | `request`  | [`Request`](https://expressjs.com/en/4x/api.html#req)  |
 | `response` | [`Response`](https://expressjs.com/en/4x/api.html#res) |
 
+## `fastify()`
+
+Middleware for Fastify.
+
+```ts
+const fastify = () => Middleware;
+```
+
+#### Usage
+
+```ts
+import { fastify } from "lucia/middleware";
+
+const auth = lucia({
+	middleware: fastify()
+	// ...
+});
+```
+
+```ts
+auth.handleRequest(request as FastifyRequest, reply as FastifyReply);
+```
+
+| name      | type                                                                              |
+| --------- | --------------------------------------------------------------------------------- |
+| `request` | [`FastifyRequest`](https://fastify.dev/docs/latest/Reference/TypeScript/#request) |
+| `reply`   | [`FastifyReply`](https://fastify.dev/docs/latest/Reference/TypeScript/#reply)     |
+
+## `h3()`
+
+Middleware for H3 (Nuxt 3).
+
+```ts
+const h3: () => Middleware;
+```
+
+#### Usage
+
+```ts
+import { h3 } from "lucia/middleware";
+
+const auth = lucia({
+	middleware: h3()
+	// ...
+});
+```
+
+```ts
+auth.handleRequest(event as H3Event);
+```
+
+| name    | type                                                  |
+| ------- | ----------------------------------------------------- |
+| `event` | [`H3Event`](https://www.jsdocs.io/package/h3#H3Event) |
+
 ## `lucia()`
 
 The default middleware.
@@ -69,7 +124,7 @@ const lucia: () => Middleware;
 #### Usage
 
 ```ts
-import { lucia as luciaMiddleware } from "lucia-auth/middleware";
+import { lucia as luciaMiddleware } from "lucia/middleware";
 
 const auth = lucia({
 	middleware: luciaMiddleware()
@@ -83,7 +138,7 @@ auth.handleRequest(requestContext as RequestContext);
 
 | name             | type                                                           |
 | ---------------- | -------------------------------------------------------------- |
-| `requestContext` | [`RequestContext`](/reference/lucia-auth/types#requestcontext) |
+| `requestContext` | [`RequestContext`](/reference/lucia/types#requestcontext) |
 
 ## `nextjs()`
 
@@ -96,7 +151,7 @@ const nextjs: () => Middleware;
 #### Usage
 
 ```ts
-import { nextjs } from "lucia-auth/middleware";
+import { nextjs } from "lucia/middleware";
 
 const auth = lucia({
 	middleware: nextjs()
@@ -152,7 +207,7 @@ const node = () => Middleware;
 #### Usage
 
 ```ts
-import { node } from "lucia-auth/middleware";
+import { node } from "lucia/middleware";
 
 const auth = lucia({
 	middleware: node()
@@ -169,33 +224,6 @@ auth.handleRequest(request as IncomingMessage, response as OutgoingMessage);
 | `request`  | [`IncomingMessage`](https://nodejs.org/api/http.html#class-httpincomingmessage) |
 | `response` | [`OutgoingMessage`](https://nodejs.org/api/http.html#class-httpoutgoingmessage) |
 
-## `h3()`
-
-Middleware for H3 (Nuxt 3).
-
-```ts
-const h3: () => Middleware;
-```
-
-#### Usage
-
-```ts
-import { h3 } from "lucia-auth/middleware";
-
-const auth = lucia({
-	middleware: h3()
-	// ...
-});
-```
-
-```ts
-auth.handleRequest(event as H3Event);
-```
-
-| name    | type                                                  |
-| ------- | ----------------------------------------------------- |
-| `event` | [`H3Event`](https://www.jsdocs.io/package/h3#H3Event) |
-
 ## `sveltekit()`
 
 Middleware for SvelteKit 1.x.
@@ -207,7 +235,7 @@ const sveltekit: () => Middleware;
 #### Usage
 
 ```ts
-import { sveltekit } from "lucia-auth/middleware";
+import { sveltekit } from "lucia/middleware";
 
 const auth = lucia({
 	middleware: sveltekit()
@@ -234,7 +262,7 @@ const web: () => Middleware;
 #### Usage
 
 ```ts
-import { web } from "lucia-auth/middleware";
+import { web } from "lucia/middleware";
 
 const auth = lucia({
 	middleware: web()
@@ -262,7 +290,7 @@ const qwik: () => Middleware;
 #### Usage
 
 ```ts
-import { qwik } from "lucia-auth/middleware";
+import { qwik } from "lucia/middleware";
 
 const auth = lucia({
 	middleware: qwik()

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -50,9 +50,11 @@
 	"author": "pilcrowonpaper",
 	"license": "MIT",
 	"devDependencies": {
+		"@fastify/cookie": "^9.0.4",
 		"@sveltejs/kit": "1.10.0",
 		"@types/express": "^4.17.17",
 		"@types/node": "^18.6.2",
+		"fastify": "^4.21.0",
 		"prettier": "^2.3.0",
 		"vitest": "^0.30.1"
 	}

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -50,7 +50,6 @@
 	"author": "pilcrowonpaper",
 	"license": "MIT",
 	"devDependencies": {
-		"@fastify/cookie": "^9.0.4",
 		"@sveltejs/kit": "1.10.0",
 		"@types/express": "^4.17.17",
 		"@types/node": "^18.6.2",

--- a/packages/lucia/src/middleware/index.ts
+++ b/packages/lucia/src/middleware/index.ts
@@ -86,18 +86,6 @@ export const express = (): Middleware<[ExpressRequest, ExpressResponse]> => {
 	};
 };
 
-/**
- * You need to register `setCookie` from:
- *
- * ```
- * import cookie from '@fastify/cookie';
- *
- * await fastify.register(cookie, {
- *  secret: 'my-secret', // for cookies signature
- *  parseOptions: {}, // options for parsing cookies
- * });
- * ```
- */
 export const fastify = (): Middleware<[FastifyRequest, FastifyReply]> => {
 	return ({ args }) => {
 		const [req, res] = args;

--- a/packages/lucia/src/middleware/index.ts
+++ b/packages/lucia/src/middleware/index.ts
@@ -12,8 +12,7 @@ import type {
 	Response as ExpressResponse
 } from "express";
 
-import "@fastify/cookie";
-import { FastifyReply, FastifyRequest } from "fastify";
+import type { FastifyReply, FastifyRequest } from "fastify";
 
 const getIncomingMessageUrl = (incomingMessage: IncomingMessage, env: Env) => {
 	if (!incomingMessage.headers.host) return "";
@@ -122,7 +121,7 @@ export const fastify = (): Middleware<[FastifyRequest, FastifyReply]> => {
 				}
 			},
 			setCookie: (cookie) => {
-				res.cookie(cookie.name, cookie.value, cookie.attributes);
+				res.header("Set-Cookie", [cookie.serialize()]);
 			}
 		} as const satisfies RequestContext;
 


### PR DESCRIPTION
This is an alternate implementation for a fastify-compatible Lucia middleware. Compared to the [existing PR](https://github.com/pilcrowOnPaper/lucia/pull/589), this adds a Fastify middleware that's nearly the same as the existing Express middleware.

This _does_ add several dev dependencies to demonstrate typesafety, and does require fastify users to _also_ install @fastify-cookie. I'm not sure what kind of impact that has on the bundle size, but would appreciate feedback or other needs to add built-in fastify support to the library.

I'd also be happy to add docs similar to the exiting Express get-started if helpful.