### PR TITLE
fix: useless query doing nothing removed // performance

### DIFF
--- a/packages/lucia/src/auth/index.ts
+++ b/packages/lucia/src/auth/index.ts
@@ -634,7 +634,6 @@ export class Auth<_Configuration extends Configuration = any> {
 	public getAllUserKeys = async (userId: string): Promise<Key[]> => {
 		const [databaseKeys] = await Promise.all([
 			await this.adapter.getKeysByUserId(userId),
-			this.getUser(userId)
 		]);
 		return databaseKeys.map((databaseKey) =>
 			this.transformDatabaseKey(databaseKey)


### PR DESCRIPTION
- in getAllUserKeys was an uneccessary call to getUser resulting in a db query. The data of the query remained unused.