### PR TITLE
Added base domain and explanation to csrfProtection

### DIFF
--- a/documentation/content/main/1.basics/7.configuration.md
+++ b/documentation/content/main/1.basics/7.configuration.md
@@ -20,6 +20,7 @@ type Configuration = {
 	csrfProtection?:
 		| boolean
 		| {
+				baseDomain: string;
 				allowedSubdomains: "*" | string[];
 		  };
 	getSessionAttributes?: (databaseSession: SessionSchema) => Record<any, any>;
@@ -84,11 +85,12 @@ Provides Lucia with the current server context.
 
 ### `csrfProtection`
 
-`true` by default. When set to `true`, [`AuthRequest.validate()`](/reference/lucia/interfaces/authrequest#validate) checks if the incoming request is from a trusted origin, which by default only includes where the server is hosted. You can define trusted subdomains by adding them to `csrfProtection.allowedSubdomains`. If your app is hosted on `https://foo.example.com`, adding `"bar"` will allow `https://bar.example.com`. You can add `null` in the array to allow urls without a subdomain.
+`true` by default. When set to `true`, [`AuthRequest.validate()`](/reference/lucia/interfaces/authrequest#validate) checks if the incoming request is from a trusted origin, which by default only includes where the server is hosted. The base domain refers to the base url of your server, such as `example.com`. You can define trusted subdomains by adding them to `csrfProtection.allowedSubdomains`. If your app is hosted on `https://foo.example.com`, adding `"bar"` will allow `https://bar.example.com`. You can add `null` in the array to allow urls without a subdomain.
 
 ```ts
 const csrfProtection = boolean | {
-	allowedSubdomains: "*" | (string | null)[]
+	baseDomain: string;
+	allowedSubdomains: "*" | (string | null)[];
 }
 ```
 
@@ -100,6 +102,7 @@ const csrfProtection = boolean | {
 
 | name                | type              | description                                                                          |
 | ------------------- | ----------------- | ------------------------------------------------------------------------------------ |
+| `baseDomain` | `string` | The base url where the server is hosted on.                                                          |
 | `allowedSubdomains` | `"*" \| string[]` | List of allowed subdomains (not full urls/origins) - set to `*` allow all subdomains |
 
 ### `getSessionAttributes()`


### PR DESCRIPTION
### Changes

- added `baseDomain` to the documentation under `csrfProtection` and the example config at the top of the configuration page. 

I stumbled upon this by sheer luck in VSCode when developing. After I migrated from the beta, Lucia stopped authenticating on production and I could not understand what was going wrong. If my explanation is incorrect please let me know.

Also wasn't sure if the PR should be made to `refactor-docs`or `main`. Let me know if I should update it as well.