### PR TITLE
feat(unstorage): add ttl support

### DIFF
--- a/.auri/$mqai142h.md
+++ b/.auri/$mqai142h.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/adapter-session-unstorage" # package name
+type: "minor" # "major", "minor", "patch"
+---
+
+Add ttl support to adapter-session-unstorage adapter

--- a/.auri/$mqai142h.md
+++ b/.auri/$mqai142h.md
@@ -3,4 +3,4 @@ package: "@lucia-auth/adapter-session-unstorage" # package name
 type: "minor" # "major", "minor", "patch"
 ---
 
-Add ttl support to adapter-session-unstorage adapter
+Add ttl support

--- a/packages/adapter-session-unstorage/package.json
+++ b/packages/adapter-session-unstorage/package.json
@@ -35,7 +35,7 @@
 	},
 	"peerDependencies": {
 		"lucia": "^2.0.0",
-		"unstorage": "^1.6.1"
+		"unstorage": "^1.9.0"
 	},
 	"devDependencies": {
 		"@lucia-auth/adapter-test": "latest",

--- a/packages/adapter-session-unstorage/src/unstorage.ts
+++ b/packages/adapter-session-unstorage/src/unstorage.ts
@@ -47,7 +47,9 @@ export const unstorageAdapter = (
 				const userSessionStorage = getUserSessionStorage(session.user_id);
 				await Promise.all([
 					userSessionStorage.setItem(session.user_id, ""),
-					sessionStorage.setItem(session.id, session)
+					sessionStorage.setItem(session.id, session, {
+						ttl: Math.floor(Number(session.idle_expires) / 1000)
+					})
 				]);
 			},
 			deleteSession: async (sessionId) => {
@@ -73,7 +75,9 @@ export const unstorageAdapter = (
 				const sessionResult = (await sessionStorage.getItem(sessionId)) ?? null;
 				if (!sessionResult) return;
 				const updatedSession = { ...sessionResult, ...partialSession };
-				await sessionStorage.setItem(sessionId, updatedSession);
+				await sessionStorage.setItem(sessionId, updatedSession, {
+					ttl: Math.floor(Number(partialSession.idle_expires) / 1000)
+				});
 			}
 		};
 	};


### PR DESCRIPTION
Ttl support is being added to unstorage through https://github.com/unjs/unstorage/issues/262
For now the vercel-kv and redis drivers are supported, but as more support is added, this will start working for all of them. 