### PR TITLE
Add link to `Handle requests` in `MainMenu`

### DIFF
--- a/documentation/src/components/menus/MainMenu.astro
+++ b/documentation/src/components/menus/MainMenu.astro
@@ -17,6 +17,7 @@ import Menu from "./Menu.astro";
 				["Database", "/basics/database"],
 				["Users", "/basics/users"],
 				["Sessions", "/basics/sessions"],
+				["Handle requests", "/basics/handle-requests"],
 				["Error handling", "/basics/error-handling"],
 				["Using cookies", "/basics/using-cookies"],
 				["Using bearer tokens", "/basics/using-bearer-tokens"],


### PR DESCRIPTION
For some reason the [Handle requests](https://lucia-auth.com/basics/handle-requests) page exists but isn't available through the main menu. This PR fixes that.
