### PR TITLE
Add link to `Keys` in `MainMenu`

### DIFF
--- a/documentation/src/components/menus/MainMenu.astro
+++ b/documentation/src/components/menus/MainMenu.astro
@@ -16,6 +16,7 @@ import Menu from "./Menu.astro";
 			pages: [
 				["Database", "/basics/database"],
 				["Users", "/basics/users"],
+				["Keys", "/basics/keys"],
 				["Sessions", "/basics/sessions"],
 				["Error handling", "/basics/error-handling"],
 				["Using cookies", "/basics/using-cookies"],


### PR DESCRIPTION
Link for basics/keys was missing in the MainMenu, so I fixed.