### PR TITLE
CI: Release

### DIFF
--- a/.auri/$f2eyvqe1.md
+++ b/.auri/$f2eyvqe1.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add `twitter()` provider (OAuth 2.0 with PKCE)

--- a/.auri/$inc6a12a.md
+++ b/.auri/$inc6a12a.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix `GithubUserAuth.githubTokens` not including refresh token

--- a/.auri/$pl9jo32d.md
+++ b/.auri/$pl9jo32d.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix `linkedin()` to use latest LinkedIn OAuth implementation

--- a/.auri/$q4pb9pqd.md
+++ b/.auri/$q4pb9pqd.md
@@ -1,8 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
-pull: "983"
----
-
-`decodeIdToken()` throws `SyntaxError`
-    - Remove `IdTokenError`

--- a/.auri/$qglfylf6.md
+++ b/.auri/$qglfylf6.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Remove unused and undocumented `csrfProtection.baseDomain` configuration

--- a/.auri/$xomh6zn0.md
+++ b/.auri/$xomh6zn0.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix Lucia throwing `AUTH_OUTDATED_PASSWORD` when using Bcrypt

--- a/.auri/$zvzn8ngu.md
+++ b/.auri/$zvzn8ngu.md
@@ -1,6 +1,0 @@
----
-package: "lucia" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Fixed `updateKeyPassword()` to return a `Promise<Key>`

--- a/packages/lucia/CHANGELOG.md
+++ b/packages/lucia/CHANGELOG.md
@@ -1,5 +1,17 @@
 # lucia
 
+## 2.4.0
+
+### Minor changes
+
+- [#986](https://github.com/pilcrowOnPaper/lucia/pull/986) by [@KazuumiN](https://github.com/KazuumiN) : Fixed `updateKeyPassword()` to return a `Promise<Key>`
+
+### Patch changes
+
+- [#980](https://github.com/pilcrowOnPaper/lucia/pull/980) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove unused and undocumented `csrfProtection.baseDomain` configuration
+
+- [#985](https://github.com/pilcrowOnPaper/lucia/pull/985) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix Lucia throwing `AUTH_OUTDATED_PASSWORD` when using Bcrypt
+
 ## 2.3.0
 
 ### Minor changes

--- a/packages/lucia/package.json
+++ b/packages/lucia/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "A simple and flexible authentication library",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @lucia-auth/oauth
 
+## 2.2.0
+
+### Minor changes
+
+- [#990](https://github.com/pilcrowOnPaper/lucia/pull/990) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `twitter()` provider (OAuth 2.0 with PKCE)
+
+- [#983](https://github.com/pilcrowOnPaper/lucia/pull/983) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : `decodeIdToken()` throws `SyntaxError`
+  - Remove `IdTokenError`
+
+### Patch changes
+
+- [#990](https://github.com/pilcrowOnPaper/lucia/pull/990) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `GithubUserAuth.githubTokens` not including refresh token
+
+- [#973](https://github.com/pilcrowOnPaper/lucia/pull/973) by [@anhtuank7c](https://github.com/anhtuank7c) : Fix `linkedin()` to use latest LinkedIn OAuth implementation
+
 ## 2.1.2
 
 ### Patch changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "2.1.2",
+	"version": "2.2.0",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/oauth@2.2.0
#### Minor changes

- [#990](https://github.com/pilcrowOnPaper/lucia/pull/990) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `twitter()` provider (OAuth 2.0 with PKCE)

- [#983](https://github.com/pilcrowOnPaper/lucia/pull/983) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : `decodeIdToken()` throws `SyntaxError`
    - Remove `IdTokenError`

#### Patch changes

- [#990](https://github.com/pilcrowOnPaper/lucia/pull/990) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `GithubUserAuth.githubTokens` not including refresh token

- [#973](https://github.com/pilcrowOnPaper/lucia/pull/973) by [@anhtuank7c](https://github.com/anhtuank7c) : Fix `linkedin()` to use latest LinkedIn OAuth implementation
### lucia@2.4.0
#### Minor changes

- [#986](https://github.com/pilcrowOnPaper/lucia/pull/986) by [@KazuumiN](https://github.com/KazuumiN) : Fixed `updateKeyPassword()` to return a `Promise<Key>`

#### Patch changes

- [#980](https://github.com/pilcrowOnPaper/lucia/pull/980) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove unused and undocumented `csrfProtection.baseDomain` configuration

- [#985](https://github.com/pilcrowOnPaper/lucia/pull/985) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix Lucia throwing `AUTH_OUTDATED_PASSWORD` when using Bcrypt