### PR TITLE
Remove `IdTokenError`

### DIFF
--- a/.auri/$q4pb9pqd.md
+++ b/.auri/$q4pb9pqd.md
@@ -1,0 +1,7 @@
+---
+package: "@lucia-auth/oauth" # package name
+type: "minor" # "major", "minor", "patch"
+---
+
+- `decodeIdToken()` throws `SyntaxError`
+    - Remove `IdTokenError`

--- a/documentation/content/reference/oauth/interfaces.md
+++ b/documentation/content/reference/oauth/interfaces.md
@@ -2,16 +2,6 @@
 title: "Interfaces"
 ---
 
-## `IdTokenError`
-
-Extends standard `Error`.
-
-```ts
-type IdTokenError = Error & {
-	message: "INVALID_ID_TOKEN";
-};
-```
-
 ## `OAuthProvider`
 
 See each provider's page.

--- a/documentation/content/reference/oauth/modules/main.md
+++ b/documentation/content/reference/oauth/modules/main.md
@@ -93,7 +93,7 @@ const createOAuth2AuthorizationUrlWithPKCE: (
 
 **This API is experimental and is subject to breaking changes.**
 
-Decodes the OpenID Connect Id Token and returns the claims. **Does NOT validate the JWT**. Throws [`IdTokenError`](/reference/oauth/interfaces#idtokenerror) if provided id token is invalid or malformed.
+Decodes the OpenID Connect Id Token and returns the claims. **Does NOT validate the JWT**. Throws `SyntaxError` if provided id token is invalid or malformed.
 
 ```ts
 import { __experimental_decodeIdToken } from "@lucia-auth/oauth";
@@ -124,10 +124,6 @@ const decodeIdToken: <_Claims extends {}>(
 ##### Returns
 
 JWT payload.
-
-## `IdTokenError`
-
-See [`IdTokenError`](/reference/oauth/interfaces#idtokenerror).
 
 ## `OAuthRequestError`
 

--- a/packages/oauth/src/core.ts
+++ b/packages/oauth/src/core.ts
@@ -198,14 +198,6 @@ export const validateOAuth2AuthorizationCode = async <_ResponseBody extends {}>(
 	return await handleRequest<_ResponseBody>(request);
 };
 
-export class IdTokenError extends Error {
-	public message: "INVALID_ID_TOKEN";
-	constructor(message: IdTokenError["message"]) {
-		super(message);
-		this.message = message;
-	}
-}
-
 const decoder = new TextDecoder();
 
 // does not verify id tokens
@@ -217,13 +209,13 @@ export const decodeIdToken = <_Claims extends {}>(
 	exp: number;
 } & _Claims => {
 	const idTokenParts = idToken.split(".");
-	if (idTokenParts.length !== 3) throw new IdTokenError("INVALID_ID_TOKEN");
+	if (idTokenParts.length !== 3) throw new SyntaxError("Invalid ID Token");
 	const base64UrlPayload = idTokenParts[1];
 	const payload: unknown = JSON.parse(
 		decoder.decode(decodeBase64Url(base64UrlPayload))
 	);
 	if (!payload || typeof payload !== "object") {
-		throw new IdTokenError("INVALID_ID_TOKEN");
+		throw new SyntaxError("Invalid ID Token");
 	}
 	return payload as {
 		iss: string;

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -4,8 +4,7 @@ export {
 	validateOAuth2AuthorizationCode as __experimental_validateOAuth2AuthorizationCode,
 	createOAuth2AuthorizationUrl as __experimental_createOAuth2AuthorizationUrl,
 	createOAuth2AuthorizationUrlWithPKCE as __experimental_createOAuth2AuthorizationUrlWithPKCE,
-	decodeIdToken as __experimental_decodeIdToken,
-	IdTokenError as __experimental_IdTokenError
+	decodeIdToken as __experimental_decodeIdToken
 } from "./core.js";
 export { generateState } from "./utils.js";
 


### PR DESCRIPTION
`decodeIdToken()` throws `SyntaxError` instead. Using `SyntaxError` is consistent with `JSON.parse()`, which throws the error if the provided JSON is malformed.