### PR TITLE
Fix `updateKeyPassword()` returning `Promise<Key>`

### DIFF
--- a/.auri/$zvzn8ngu.md
+++ b/.auri/$zvzn8ngu.md
@@ -1,6 +1,6 @@
 ---
 package: "lucia" # package name
-type: "patch" # "major", "minor", "patch"
+type: "minor" # "major", "minor", "patch"
 ---
 
 Fixed `updateKeyPassword()` to return a `Promise<Key>`

--- a/.auri/$zvzn8ngu.md
+++ b/.auri/$zvzn8ngu.md
@@ -1,0 +1,6 @@
+---
+package: "lucia" # package name
+type: "patch" # "major", "minor", "patch"
+---
+
+Fixed `updateKeyPassword()` to return a `Promise<Key>`

--- a/packages/lucia/src/auth/index.ts
+++ b/packages/lucia/src/auth/index.ts
@@ -645,14 +645,14 @@ export class Auth<_Configuration extends Configuration = any> {
 		providerId: string,
 		providerUserId: string,
 		password: string | null
-	): Promise<void> => {
+	): Promise<Key> => {
 		const keyId = createKeyId(providerId, providerUserId);
 		const hashedPassword =
 			password === null ? null : await this.passwordHash.generate(password);
 		await this.adapter.updateKey(keyId, {
 			hashed_password: hashedPassword
 		});
-		await this.getKey(providerId, providerUserId);
+		return await this.getKey(providerId, providerUserId);
 	};
 }
 type MaybePromise<T> = T | Promise<T>;


### PR DESCRIPTION
Fixed `updateKeyPassword()` to return a `Promise<Key>`