### PR TITLE
CI: Release

### DIFF
--- a/.auri/$4tvios4d.md
+++ b/.auri/$4tvios4d.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add Salesforce provider

--- a/.auri/$50cmkct.md
+++ b/.auri/$50cmkct.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Experimental API `createOAuth2AuthorizationUrl()`, `createOAuth2AuthorizationUrlWithPKCE()`, `validateOAuth2AuthorizationCode()`, and `decodeIdToken()` are now stable

--- a/.auri/$50cmkct2.md
+++ b/.auri/$50cmkct2.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Update `createOAuth2AuthorizationUrlWithPKCE()` return type

--- a/.auri/$50cmkcw.md
+++ b/.auri/$50cmkcw.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Remove `generateState()` export

--- a/.auri/$50cmkcw4.md
+++ b/.auri/$50cmkcw4.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Replace `OAuthProvider` with `OAuth2ProviderAuth` and `OAuth2ProviderAuthWithPKCE`

--- a/.auri/$50cmkcwp.md
+++ b/.auri/$50cmkcwp.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Replace `GithubProvider` with `GithubAuth` etc

--- a/.auri/$6qq2nr4z.md
+++ b/.auri/$6qq2nr4z.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add Box provider

--- a/.auri/$90975ol0.md
+++ b/.auri/$90975ol0.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/adapter-postgresql" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix release of connection for transaction in pg

--- a/.auri/$9dl3rkfo.md
+++ b/.auri/$9dl3rkfo.md
@@ -1,7 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
-pull: "1005"
----
-
-Add Azure Active Directory provider

--- a/.auri/$aydq7n8b.md
+++ b/.auri/$aydq7n8b.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add Atlassian provider

--- a/.auri/$enb1f08l.md
+++ b/.auri/$enb1f08l.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Rename `linkedin()`, type `LinkedinUser`, and type `LinkedinTokens` to `linkedIn()`, `LinkedInUser`, and `LinkedInTokens`

--- a/.auri/$gva98mzr.md
+++ b/.auri/$gva98mzr.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add Line provider

--- a/.auri/$ixlmonvt.md
+++ b/.auri/$ixlmonvt.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth"
-type: "patch"
----
-
-Add `global_name` and `avatar_decoration` fields in `DiscordUser` type

--- a/.auri/$ncghazw5.md
+++ b/.auri/$ncghazw5.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/minor" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add Dropbox provider

--- a/.auri/$rrtmh3vf.md
+++ b/.auri/$rrtmh3vf.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add Gitlab provider

--- a/.auri/$upyc164d.md
+++ b/.auri/$upyc164d.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add Bitbucket provider

--- a/.auri/$vviw6hwy.md
+++ b/.auri/$vviw6hwy.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "patch" # "major", "minor", "patch"
----
-
-Fix `validateOAuth2AuthorizationCode()` sending malformed basic auth headers

--- a/.auri/$znnf49ht.md
+++ b/.auri/$znnf49ht.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Remove `options.searchParams` and `options.state` from `createOAuth2AuthorizationUrl()` and `createOAuth2AuthorizationUrlWithPKCE()` params

--- a/.auri/$znnf49htd.md
+++ b/.auri/$znnf49htd.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "major" # "major", "minor", "patch"
----
-
-Update `auth0()`, `patreon()`, `reddit()`, `spotify()`, `twitch()` params

--- a/.auri/$zr0k9t3z.md
+++ b/.auri/$zr0k9t3z.md
@@ -1,6 +1,0 @@
----
-package: "@lucia-auth/oauth" # package name
-type: "minor" # "major", "minor", "patch"
----
-
-Add Slack provider

--- a/documentation/content/guidebook/email-verification-codes.md
+++ b/documentation/content/guidebook/email-verification-codes.md
@@ -13,7 +13,7 @@ An alternative way to verify emails is to use one-time passwords. These are gene
 | ------- | -------- | :----: | ---------- | ------------------------------------- |
 | id      | any      |   ✓    |            | PRIMARY KEY                           |
 | user_id | `string` |   ✓    | `user(id)` | User id                               |
-| code    | `string`  |        |            | Verification code                     |
+| code    | `string` |        |            | Verification code                     |
 | expires | `bigint` |        |            | `int4` and `timestamp` type works too |
 
 ## Generate and send verification code

--- a/packages/adapter-postgresql/CHANGELOG.md
+++ b/packages/adapter-postgresql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lucia-auth/adapter-postgresql
 
+## 2.0.1
+
+### Patch changes
+
+- [#1031](https://github.com/pilcrowOnPaper/lucia/pull/1031) by [@kosei28](https://github.com/kosei28) : Fix release of connection for transaction in pg
+
 ## 2.0.0
 
 ### Major changes

--- a/packages/adapter-postgresql/package.json
+++ b/packages/adapter-postgresql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-postgresql",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "PostgreSQL adapter for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,49 @@
 # @lucia-auth/oauth
 
+## 3.0.0
+
+### Major changes
+
+- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `generateState()` export
+
+- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Replace `OAuthProvider` with `OAuth2ProviderAuth` and `OAuth2ProviderAuthWithPKCE`
+
+- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Replace `GithubProvider` with `GithubAuth` etc
+
+- [#1022](https://github.com/pilcrowOnPaper/lucia/pull/1022) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Rename `linkedin()`, type `LinkedinUser`, and type `LinkedinTokens` to `linkedIn()`, `LinkedInUser`, and `LinkedInTokens`
+
+- [#1024](https://github.com/pilcrowOnPaper/lucia/pull/1024) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `auth0()`, `patreon()`, `reddit()`, `spotify()`, `twitch()` params
+
+### Minor changes
+
+- [#1011](https://github.com/pilcrowOnPaper/lucia/pull/1011) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Salesforce provider
+
+- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Experimental API `createOAuth2AuthorizationUrl()`, `createOAuth2AuthorizationUrlWithPKCE()`, `validateOAuth2AuthorizationCode()`, and `decodeIdToken()` are now stable
+
+- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `createOAuth2AuthorizationUrlWithPKCE()` return type
+
+- [#1016](https://github.com/pilcrowOnPaper/lucia/pull/1016) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Box provider
+
+- [#1005](https://github.com/pilcrowOnPaper/lucia/pull/1005) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Azure Active Directory provider
+
+- [#1012](https://github.com/pilcrowOnPaper/lucia/pull/1012) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Atlassian provider
+
+- [#1015](https://github.com/pilcrowOnPaper/lucia/pull/1015) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Line provider
+
+- [#1013](https://github.com/pilcrowOnPaper/lucia/pull/1013) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Gitlab provider
+
+- [#1017](https://github.com/pilcrowOnPaper/lucia/pull/1017) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Bitbucket provider
+
+- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `options.searchParams` and `options.state` from `createOAuth2AuthorizationUrl()` and `createOAuth2AuthorizationUrlWithPKCE()` params
+
+- [#1011](https://github.com/pilcrowOnPaper/lucia/pull/1011) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Slack provider
+
+### Patch changes
+
+- [#1024](https://github.com/pilcrowOnPaper/lucia/pull/1024) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `global_name` and `avatar_decoration` fields in `DiscordUser` type
+
+- [#1023](https://github.com/pilcrowOnPaper/lucia/pull/1023) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `validateOAuth2AuthorizationCode()` sending malformed basic auth headers
+
 ## 2.2.0
 
 ### Minor changes
@@ -7,6 +51,7 @@
 - [#990](https://github.com/pilcrowOnPaper/lucia/pull/990) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `twitter()` provider (OAuth 2.0 with PKCE)
 
 - [#983](https://github.com/pilcrowOnPaper/lucia/pull/983) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : `decodeIdToken()` throws `SyntaxError`
+
   - Remove `IdTokenError`
 
 ### Patch changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "2.2.0",
+	"version": "3.0.0",
 	"description": "OAuth integration for Lucia",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This is a pull request automatically created by Auri. You can approve this pull request to update changelogs and publish packages.

## Releases

### @lucia-auth/oauth@3.0.0
#### Major changes

- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `generateState()` export

- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Replace `OAuthProvider` with `OAuth2ProviderAuth` and `OAuth2ProviderAuthWithPKCE`

- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Replace `GithubProvider` with `GithubAuth` etc

- [#1022](https://github.com/pilcrowOnPaper/lucia/pull/1022) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Rename `linkedin()`, type `LinkedinUser`, and type `LinkedinTokens` to `linkedIn()`, `LinkedInUser`, and `LinkedInTokens`

- [#1024](https://github.com/pilcrowOnPaper/lucia/pull/1024) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `auth0()`, `patreon()`, `reddit()`, `spotify()`, `twitch()` params

#### Minor changes

- [#1011](https://github.com/pilcrowOnPaper/lucia/pull/1011) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Salesforce provider

- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Experimental API `createOAuth2AuthorizationUrl()`, `createOAuth2AuthorizationUrlWithPKCE()`, `validateOAuth2AuthorizationCode()`, and `decodeIdToken()` are now stable

- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Update `createOAuth2AuthorizationUrlWithPKCE()` return type

- [#1016](https://github.com/pilcrowOnPaper/lucia/pull/1016) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Box provider

- [#1005](https://github.com/pilcrowOnPaper/lucia/pull/1005) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Azure Active Directory provider

- [#1012](https://github.com/pilcrowOnPaper/lucia/pull/1012) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Atlassian provider

- [#1015](https://github.com/pilcrowOnPaper/lucia/pull/1015) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Line provider

- [#1013](https://github.com/pilcrowOnPaper/lucia/pull/1013) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Gitlab provider

- [#1017](https://github.com/pilcrowOnPaper/lucia/pull/1017) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Bitbucket provider

- [#993](https://github.com/pilcrowOnPaper/lucia/pull/993) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Remove `options.searchParams` and `options.state` from `createOAuth2AuthorizationUrl()` and `createOAuth2AuthorizationUrlWithPKCE()` params

- [#1011](https://github.com/pilcrowOnPaper/lucia/pull/1011) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Slack provider

#### Patch changes

- [#1024](https://github.com/pilcrowOnPaper/lucia/pull/1024) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add `global_name` and `avatar_decoration` fields in `DiscordUser` type

- [#1023](https://github.com/pilcrowOnPaper/lucia/pull/1023) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Fix `validateOAuth2AuthorizationCode()` sending malformed basic auth headers
### @lucia-auth/adapter-postgresql@2.0.1
#### Patch changes

- [#1031](https://github.com/pilcrowOnPaper/lucia/pull/1031) by [@kosei28](https://github.com/kosei28) : Fix release of connection for transaction in pg