### PR TITLE
docs: add links to middleware-setup in astro-docs

### DIFF
--- a/documentation/content/guidebook/github-oauth/$astro.md
+++ b/documentation/content/guidebook/github-oauth/$astro.md
@@ -3,7 +3,7 @@ title: "Github OAuth in Astro"
 description: "Learn the basic of Lucia and the OAuth integration by implementing Github OAuth"
 ---
 
-_Before starting, make sure you've [setup Lucia and your database](/getting-started/astro) and that you've implement the recommended middleware._
+_Before starting, make sure you've [setup Lucia and your database](/getting-started/astro) and that you've implement the [recommended middleware](/getting-started/astro#set-up-middleware)._
 
 This guide will cover how to implement Github OAuth using Lucia in Astro. It will have 3 parts:
 

--- a/documentation/content/guidebook/sign-in-with-username-and-password/$astro.md
+++ b/documentation/content/guidebook/sign-in-with-username-and-password/$astro.md
@@ -3,7 +3,7 @@ title: "Sign in with username and password in Astro"
 description: "Learn the basic of Lucia by implementing a basic username and password authentication"
 ---
 
-_Before starting, make sure you've [setup Lucia and your database](/getting-started/astro) and that you've implement the recommended middleware._
+_Before starting, make sure you've [setup Lucia and your database](/getting-started/astro) and that you've implement the [recommended middleware](/getting-started/astro#set-up-middleware)._
 
 This guide will cover how to implement a simple username and password authentication using Lucia in Astro. It will have 3 parts:
 


### PR DESCRIPTION
In `guidebook/sign-in-with-username-and-password/astro` and `guidebook/github-oauth/astro` there was a mention of `recommended middleware` but it wasn't directly clear what was meant. It's especially confusing since `middleware` is also used as a key in the lucia-config.

I added links to the `set up middleware` header in `getting-started/astro`.

There was another mention of recommended middleware in `solidstart`'s docs, but I couldn't find the middleware-paragraph it referenced. Since it's not visible yet in the integrations-page I assume it's not yet finished.

sidenote: to test out in `dev` I had to wrap the fetch inside `utils/github` in a `try-catch`, since I don't have ur api-key.