### PR TITLE
OAuth: Update documentation links

### DIFF
--- a/documentation/content/oauth/basics/oauth2-pkce.md
+++ b/documentation/content/oauth/basics/oauth2-pkce.md
@@ -3,7 +3,7 @@ title: "OAuth 2.0 with PKCE"
 description: "Learn how to implement OAuth 2.0 with PKCE"
 ---
 
-This page covers OAuth 2.0 authorization code grant type. For OAuth 2.0 providers with PKCE, see [OAuth 2.0 with PKCE](/oauth/baiscs/oauth2).
+This page covers OAuth 2.0 authorization code grant type with PKCE. For OAuth 2.0 providers without PKCE, see [OAuth 2.0 without PKCE](/oauth/basics/oauth2).
 
 Examples shown here uses Twitter OAuth but the API and overall process is nearly across providers. See each provider's documentation (from the sidebar) for specifics.
 

--- a/documentation/content/oauth/basics/oauth2.md
+++ b/documentation/content/oauth/basics/oauth2.md
@@ -3,7 +3,7 @@ title: "OAuth 2.0"
 description: "Learn how to implement OAuth 2.0"
 ---
 
-This page covers OAuth 2.0 authorization code grant type with PKCE. For OAuth 2.0 providers without PKCE, see [OAuth 2.0 with PKCE](/oauth/basics/oauth2-pkce).
+This page covers OAuth 2.0 authorization code grant type. For OAuth 2.0 providers with PKCE, see [OAuth 2.0 with PKCE](/oauth/basics/oauth2-pkce).
 
 Examples shown here uses Github OAuth but the API and overall process is nearly across providers. See each provider's documentation (from the sidebar) for specifics.
 

--- a/documentation/content/oauth/index.md
+++ b/documentation/content/oauth/index.md
@@ -15,7 +15,7 @@ pnpm add @lucia-auth/oauth
 yarn add @lucia-auth/oauth
 ```
 
-Get started with [OAuth 2.0 authorization code grant type](/oauth/basics/oauth2) or [OAuth 2.0 with PKCE](/oauth2/oauth2-pkce).
+Get started with [OAuth 2.0 authorization code grant type](/oauth/basics/oauth2) or [OAuth 2.0 with PKCE](/oauth/basics/oauth2-pkce).
 
 ## Step-by-step guides
 


### PR DESCRIPTION
Correct link to oauth/basics/oauth2-pkce