### PR TITLE
feat(adapters): add drizzle-orm support

### DIFF
--- a/packages/adapter-drizzle/.gitignore
+++ b/packages/adapter-drizzle/.gitignore
@@ -1,0 +1,5 @@
+/node_modules
+/dist
+.DS_Store
+.env
+*.tgz

--- a/packages/adapter-drizzle/package.json
+++ b/packages/adapter-drizzle/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@lucia-auth/adapter-drizzle",
+	"version": "1.0.0",
+	"description": "Drizzle adapter for Lucia",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"module": "dist/index.js",
+	"type": "module",
+	"files": [
+		"/dist/",
+		"CHANGELOG.md"
+	],
+	"scripts": {
+		"build": "shx rm -rf ./dist/* && tsc",
+		"test": "tsx test/index.ts",
+		"auri.build": "pnpm build"
+	},
+	"keywords": [],
+	"author": "tajkirkpatrick",
+	"license": "MIT",
+	"exports": {
+		".": "./dist/index.js"
+	},
+	"peerDependencies": {
+		"lucia": "workspace:*",
+		"drizzle-orm": "^0.28.5"
+	},
+	"devDependencies": {
+		"@lucia-auth/adapter-test": "workspace:*",
+		"lucia": "workspace:*",
+		"drizzle-orm": "^0.28.5"
+	}
+}

--- a/packages/adapter-drizzle/src/drivers/mysql.ts
+++ b/packages/adapter-drizzle/src/drivers/mysql.ts
@@ -1,0 +1,287 @@
+import { eq } from "drizzle-orm";
+import {
+	mysqlTable as defaultMySqlTableFn,
+	varchar,
+	MySqlTableFn,
+	MySqlDatabase,
+	bigint
+} from "drizzle-orm/mysql-core";
+
+import type { Adapter, InitializeAdapter, KeySchema, UserSchema } from "lucia";
+import type { myDrizzleError } from "../drizzle.js";
+
+export function createTables(
+	mySqlTable: MySqlTableFn,
+	modelNames: {
+		user: string;
+		session: string | null;
+		key: string;
+	}
+) {
+	const user = mySqlTable(modelNames.user, {
+		id: varchar("id", {
+			length: 15 // change this when using custom user ids
+		}).primaryKey()
+		// other user attributes
+	});
+
+	const key = mySqlTable(modelNames.key, {
+		id: varchar("id", {
+			length: 255
+		}).primaryKey(),
+		userId: varchar("user_id", {
+			length: 15
+		})
+			.notNull()
+			.references(() => user.id),
+		hashedPassword: varchar("hashed_password", {
+			length: 255
+		})
+	});
+
+	const session = mySqlTable(modelNames.session ?? "auth_session", {
+		id: varchar("id", {
+			length: 128
+		}).primaryKey(),
+		userId: varchar("user_id", {
+			length: 15
+		})
+			.notNull()
+			.references(() => user.id),
+		activeExpires: bigint("active_expires", {
+			mode: "number"
+		}).notNull(),
+		idleExpires: bigint("idle_expires", {
+			mode: "number"
+		}).notNull()
+	});
+
+	return { session, user, key };
+}
+
+export function mySqlDrizzleAdapter(
+	client: InstanceType<typeof MySqlDatabase>,
+	tableFn = defaultMySqlTableFn,
+	modelNames: {
+		user: string;
+		session: string | null;
+		key: string;
+	}
+): InitializeAdapter<Adapter> {
+	const { user, key, session } = createTables(tableFn, modelNames);
+
+	const $transaction = <_Query extends (...args: any) => any>(
+		query: _Query
+	): void => {
+		client.transaction(async (trx) => {
+			try {
+				const result = await query(trx)();
+				return result;
+			} catch (e) {
+				trx.rollback();
+				throw e;
+			}
+		});
+	};
+
+	return (luciaError) => {
+		return {
+			// getSessionAndUser: async (sessionId) => {
+			//   const records = await client
+			//     .select()
+			//     .from(session)
+			//     .leftJoin(user, eq(session.userId, user.id))
+			//     .where(eq(session.id, sessionId))
+			//     // .leftJoin(user, eq(session.userId, user.id))
+			//     .then((res) => res ?? [null, null]);
+
+			//   return records;
+			// },
+			getUser: async (userId: string) => {
+				const record =
+					(await client
+						.select()
+						.from(user)
+						.where(eq(user.id, userId))
+						.then((res) => res[0])) ?? null;
+
+				return record;
+			},
+			setUser: async (userData: UserSchema, keyData: KeySchema | null) => {
+				if (!keyData) {
+					await client.insert(user).values({ ...userData, id: userData.id });
+					return;
+				}
+				try {
+					$transaction(async () => {
+						await client.insert(user).values({ ...userData, id: userData.id });
+
+						const { hashed_password, user_id, ...restKeyData } = keyData;
+
+						await client.insert(key).values({
+							...restKeyData,
+							hashedPassword: hashed_password,
+							userId: user_id
+						});
+					});
+				} catch (e) {
+					const error = e as Partial<myDrizzleError>;
+					if (error.message?.includes("`id`"))
+						throw new luciaError("AUTH_DUPLICATE_KEY_ID");
+					throw error;
+				}
+			},
+			deleteUser: async (userId) => {
+				await client.delete(user).where(eq(user.id, userId));
+			},
+			updateUser: async (userId, partialUser) => {
+				try {
+					await client
+						.update(user)
+						.set({ ...partialUser })
+						.where(eq(user.id, userId));
+				} catch (e) {
+					const error = e as Partial<myDrizzleError>;
+					if (error.message?.includes("`id`"))
+						throw new luciaError("AUTH_INVALID_USER_ID");
+					throw error;
+				}
+			},
+			getSession: async (sessionId) => {
+				const record = await client
+					.select()
+					.from(session)
+					.where(eq(session.id, sessionId))
+					.then((res) => res[0] ?? null);
+
+				return {
+					id: record?.id!,
+					user_id: record?.userId!,
+					active_expires: record?.activeExpires!,
+					idle_expires: record?.idleExpires!
+				};
+			},
+			getSessionsByUserId: async (userId) => {
+				const records = await client
+					.select()
+					.from(session)
+					.where(eq(session.userId, userId))
+					.then((res) => res ?? []);
+
+				const resultRecords = records.map((record) => ({
+					id: record.id!,
+					user_id: record.userId!,
+					active_expires: record.activeExpires!,
+					idle_expires: record.idleExpires!
+				}));
+
+				return resultRecords;
+			},
+			setSession: async (sessionData) => {
+				try {
+					const { active_expires, idle_expires, user_id, ...restSessionData } =
+						sessionData;
+					await client.insert(session).values({
+						...restSessionData,
+						activeExpires: active_expires,
+						idleExpires: idle_expires,
+						userId: user_id
+					});
+				} catch (e) {
+					const error = e as Partial<myDrizzleError>;
+					if (error.message?.includes("`id`"))
+						throw new luciaError("AUTH_INVALID_USER_ID");
+					throw error;
+				}
+			},
+			deleteSession: async (sessionId) => {
+				await client.delete(session).where(eq(session.id, sessionId));
+			},
+			deleteSessionsByUserId: async (userId) => {
+				await client.delete(session).where(eq(session.userId, userId));
+			},
+			updateSession: async (sessionId, partialSession) => {
+				try {
+					await client
+						.update(session)
+						.set({ ...partialSession })
+						.where(eq(session.id, sessionId));
+				} catch (e) {
+					const error = e as Partial<myDrizzleError>;
+					if (error.message?.includes("`id`"))
+						throw new luciaError("AUTH_INVALID_SESSION_ID");
+					throw error;
+				}
+			},
+			getKey: async (keyId) => {
+				const record = await client
+					.select()
+					.from(key)
+					.where(eq(key.id, keyId))
+					.then((res) => res[0] ?? null);
+
+				return {
+					id: record?.id!,
+					user_id: record?.userId!,
+					hashed_password: record?.hashedPassword!
+				};
+			},
+			getKeysByUserId: async (userId) => {
+				const records = await client
+					.select()
+					.from(key)
+					.where(eq(key.userId, userId))
+					.then((res) => res ?? []);
+
+				const resultRecords = records.map((record) => ({
+					id: record.id!,
+					user_id: record.userId!,
+					hashed_password: record.hashedPassword!
+				}));
+
+				return resultRecords;
+			},
+			setKey: async (keyData) => {
+				try {
+					await client
+						.insert(key)
+						.values({ ...keyData, userId: keyData.user_id });
+				} catch (e) {
+					const error = e as Partial<myDrizzleError>;
+					if (error.message?.includes("`id`"))
+						throw new luciaError("AUTH_INVALID_USER_ID");
+					throw error;
+				}
+			},
+			deleteKey: async (keyId) => {
+				await client.delete(key).where(eq(key.id, keyId));
+			},
+			deleteKeysByUserId: async (userId) => {
+				await client.delete(key).where(eq(key.userId, userId));
+			},
+			updateKey: async (keyId, partialKey) => {
+				try {
+					const { hashed_password, user_id, ...restPartialKey } = partialKey;
+
+					if (hashed_password === undefined || user_id === undefined) {
+						throw new Error("Missing updateKey data");
+					}
+
+					await client
+						.update(key)
+						.set({
+							hashedPassword: hashed_password,
+							userId: user_id,
+							...restPartialKey
+						})
+						.where(eq(key.id, keyId));
+				} catch (e) {
+					const error = e as Partial<myDrizzleError>;
+					if (error.message?.includes("`id`"))
+						throw new luciaError("AUTH_INVALID_KEY_ID");
+					throw error;
+				}
+			}
+		};
+	};
+}

--- a/packages/adapter-drizzle/src/drivers/pg.ts
+++ b/packages/adapter-drizzle/src/drivers/pg.ts
@@ -1,0 +1,287 @@
+import { eq } from "drizzle-orm";
+import type { Adapter, InitializeAdapter, KeySchema, UserSchema } from "lucia";
+import {
+  pgTable as defaultPgTableFn,
+  PgTableFn,
+  PgDatabase,
+  varchar,
+  bigint,
+} from "drizzle-orm/pg-core";
+
+import type { myDrizzleError } from "../adapter";
+
+export function createTables(
+  pgTable: PgTableFn,
+  modelNames: {
+    user: string;
+    session: string | null;
+    key: string;
+  }
+) {
+  const user = pgTable(modelNames.user, {
+    id: varchar("id", {
+      length: 15, // change this when using custom user ids
+    }).primaryKey(),
+    // other user attributes
+  });
+
+  const session = pgTable(modelNames.session ?? "user_session", {
+    id: varchar("id", {
+      length: 128,
+    }).primaryKey(),
+    userId: varchar("user_id", {
+      length: 15,
+    })
+      .notNull()
+      .references(() => user.id),
+    activeExpires: bigint("active_expires", {
+      mode: "number",
+    }).notNull(),
+    idleExpires: bigint("idle_expires", {
+      mode: "number",
+    }).notNull(),
+  });
+
+  const key = pgTable(modelNames.key, {
+    id: varchar("id", {
+      length: 255,
+    }).primaryKey(),
+    userId: varchar("user_id", {
+      length: 15,
+    })
+      .notNull()
+      .references(() => user.id),
+    hashedPassword: varchar("hashed_password", {
+      length: 255,
+    }),
+  });
+
+  return { session, user, key };
+}
+
+export function pgDrizzleAdapter(
+  client: InstanceType<typeof PgDatabase>,
+  tableFn = defaultPgTableFn,
+  modelNames: {
+    user: string;
+    session: string | null;
+    key: string;
+  }
+): InitializeAdapter<Adapter> {
+  const { user, key, session } = createTables(tableFn, modelNames);
+
+  const $transaction = <_Query extends (...args: any) => any>(
+    query: _Query
+  ): void => {
+    client.transaction(async (trx) => {
+      try {
+        const result = await query(trx)();
+        return result;
+      } catch (e) {
+        trx.rollback();
+        throw e;
+      }
+    });
+  };
+
+  return (luciaError) => {
+    return {
+      // getSessionAndUser: async (sessionId) => {
+      //   const records = await client
+      //     .select()
+      //     .from(session)
+      //     .leftJoin(user, eq(session.userId, user.id))
+      //     .where(eq(session.id, sessionId))
+      //     // .leftJoin(user, eq(session.userId, user.id))
+      //     .then((res) => res ?? [null, null]);
+
+      //   return records;
+      // },
+      getUser: async (userId: string) => {
+        const record =
+          (await client
+            .select()
+            .from(user)
+            .where(eq(user.id, userId))
+            .then((res) => res[0])) ?? null;
+
+        return record;
+      },
+      setUser: async (userData: UserSchema, keyData: KeySchema | null) => {
+        if (!keyData) {
+          await client.insert(user).values({ ...userData, id: userData.id });
+          return;
+        }
+        try {
+          $transaction(async () => {
+            await client.insert(user).values({ ...userData, id: userData.id });
+
+            const { hashed_password, user_id, ...restKeyData } = keyData;
+
+            await client.insert(key).values({
+              ...restKeyData,
+              hashedPassword: hashed_password,
+              userId: user_id,
+            });
+          });
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_DUPLICATE_KEY_ID");
+          throw error;
+        }
+      },
+      deleteUser: async (userId) => {
+        await client.delete(user).where(eq(user.id, userId));
+      },
+      updateUser: async (userId, partialUser) => {
+        try {
+          await client
+            .update(user)
+            .set({ ...partialUser })
+            .where(eq(user.id, userId));
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_INVALID_USER_ID");
+          throw error;
+        }
+      },
+      getSession: async (sessionId) => {
+        const record = await client
+          .select()
+          .from(session)
+          .where(eq(session.id, sessionId))
+          .then((res) => res[0] ?? null);
+
+        return {
+          id: record?.id!,
+          active_expires: record?.activeExpires!,
+          idle_expires: record?.idleExpires!,
+          user_id: record?.userId!,
+        };
+      },
+      getSessionsByUserId: async (userId) => {
+        const records = await client
+          .select()
+          .from(session)
+          .where(eq(session.userId, userId))
+          .then((res) => res ?? []);
+
+        const resultRecords = records.map((record) => ({
+          id: record.id!,
+          active_expires: record.activeExpires!,
+          idle_expires: record.idleExpires!,
+          user_id: record.userId!,
+        }));
+
+        return resultRecords;
+      },
+      setSession: async (sessionData) => {
+        try {
+          const { active_expires, idle_expires, user_id, ...restSessionData } =
+            sessionData;
+          await client.insert(session).values({
+            ...restSessionData,
+            activeExpires: active_expires,
+            idleExpires: idle_expires,
+            userId: user_id,
+          });
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_INVALID_USER_ID");
+          throw error;
+        }
+      },
+      deleteSession: async (sessionId) => {
+        await client.delete(session).where(eq(session.id, sessionId));
+      },
+      deleteSessionsByUserId: async (userId) => {
+        await client.delete(session).where(eq(session.userId, userId));
+      },
+      updateSession: async (sessionId, partialSession) => {
+        try {
+          await client
+            .update(session)
+            .set({ ...partialSession })
+            .where(eq(session.id, sessionId));
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_INVALID_SESSION_ID");
+          throw error;
+        }
+      },
+      getKey: async (keyId) => {
+        const record = await client
+          .select()
+          .from(key)
+          .where(eq(key.id, keyId))
+          .then((res) => res[0] ?? null);
+
+        return {
+          id: record?.id!,
+          hashed_password: record?.hashedPassword!,
+          user_id: record?.userId!,
+        };
+      },
+      getKeysByUserId: async (userId) => {
+        const records = await client
+          .select()
+          .from(key)
+          .where(eq(key.userId, userId))
+          .then((res) => res ?? []);
+
+        const resultRecords = records.map((record) => ({
+          id: record.id!,
+          hashed_password: record.hashedPassword!,
+          user_id: record.userId!,
+        }));
+
+        return resultRecords;
+      },
+      setKey: async (keyData) => {
+        try {
+          await client
+            .insert(key)
+            .values({ ...keyData, userId: keyData.user_id });
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_INVALID_USER_ID");
+          throw error;
+        }
+      },
+      deleteKey: async (keyId) => {
+        await client.delete(key).where(eq(key.id, keyId));
+      },
+      deleteKeysByUserId: async (userId) => {
+        await client.delete(key).where(eq(key.userId, userId));
+      },
+      updateKey: async (keyId, partialKey) => {
+        try {
+          const { hashed_password, user_id, ...restPartialKey } = partialKey;
+
+          if (hashed_password === undefined || user_id === undefined) {
+            throw new Error("Missing updateKey data");
+          }
+
+          await client
+            .update(key)
+            .set({
+              hashedPassword: hashed_password,
+              userId: user_id,
+              ...restPartialKey,
+            })
+            .where(eq(key.id, keyId));
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_INVALID_KEY_ID");
+          throw error;
+        }
+      },
+    };
+  };
+}

--- a/packages/adapter-drizzle/src/drivers/sqlite.ts
+++ b/packages/adapter-drizzle/src/drivers/sqlite.ts
@@ -1,0 +1,277 @@
+import { eq } from "drizzle-orm";
+import {
+  sqliteTable as defaultSqliteTableFn,
+  text,
+  BaseSQLiteDatabase,
+  SQLiteTableFn,
+  blob,
+} from "drizzle-orm/sqlite-core";
+
+import type { Adapter, InitializeAdapter, KeySchema, UserSchema } from "lucia";
+import type { myDrizzleError } from "../adapter";
+
+export function createTables(
+  sqliteTable: SQLiteTableFn,
+  modelNames: {
+    user: string;
+    session: string | null;
+    key: string;
+  }
+) {
+  const user = sqliteTable(modelNames.user, {
+    id: text("id").primaryKey(),
+    // other user attributes
+  });
+
+  const session = sqliteTable(modelNames.session ?? "user_session", {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id),
+    activeExpires: blob("active_expires", {
+      mode: "bigint",
+    }).notNull(),
+    idleExpires: blob("idle_expires", {
+      mode: "bigint",
+    }).notNull(),
+  });
+
+  const key = sqliteTable(modelNames.key, {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id),
+    hashedPassword: text("hashed_password"),
+  });
+
+  return { session, user, key };
+}
+
+export function SQLiteDrizzleAdapter(
+  client: InstanceType<typeof BaseSQLiteDatabase>,
+  tableFn = defaultSqliteTableFn,
+  modelNames: {
+    user: string;
+    session: string | null;
+    key: string;
+  }
+): InitializeAdapter<Adapter> {
+  const { user, key, session } = createTables(tableFn, modelNames);
+
+  const $transaction = <_Query extends (...args: any) => any>(
+    query: _Query
+  ): void => {
+    client.transaction(async (trx) => {
+      try {
+        const result = await query(trx)();
+        return result;
+      } catch (e) {
+        trx.rollback();
+        throw e;
+      }
+    });
+  };
+
+  return (luciaError) => {
+    return {
+      // getSessionAndUser: async (sessionId) => {
+      //   const records = await client
+      //     .select()
+      //     .from(session)
+      //     .leftJoin(user, eq(session.userId, user.id))
+      //     .where(eq(session.id, sessionId))
+      //     // .leftJoin(user, eq(session.userId, user.id))
+      //     .then((res) => res ?? [null, null]);
+
+      //   return records;
+      // },
+      getUser: async (userId: string) => {
+        const record =
+          (await client
+            .select()
+            .from(user)
+            .where(eq(user.id, userId))
+            .then((res) => res[0])) ?? null;
+
+        return record;
+      },
+      setUser: async (userData: UserSchema, keyData: KeySchema | null) => {
+        if (!keyData) {
+          await client.insert(user).values({ ...userData, id: userData.id });
+          return;
+        }
+        try {
+          $transaction(async () => {
+            await client.insert(user).values({ ...userData, id: userData.id });
+
+            const { hashed_password, user_id, ...restKeyData } = keyData;
+
+            await client.insert(key).values({
+              ...restKeyData,
+              hashedPassword: hashed_password,
+              userId: user_id,
+            });
+          });
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_DUPLICATE_KEY_ID");
+          throw error;
+        }
+      },
+      deleteUser: async (userId) => {
+        await client.delete(user).where(eq(user.id, userId));
+      },
+      updateUser: async (userId, partialUser) => {
+        try {
+          await client
+            .update(user)
+            .set({ ...partialUser })
+            .where(eq(user.id, userId));
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_INVALID_USER_ID");
+          throw error;
+        }
+      },
+      getSession: async (sessionId) => {
+        const record = await client
+          .select()
+          .from(session)
+          .where(eq(session.id, sessionId))
+          .then((res) => res[0] ?? null);
+
+        return {
+          id: record?.id!,
+          active_expires: Number(record?.activeExpires),
+          idle_expires: Number(record?.idleExpires),
+          user_id: record?.userId!,
+        };
+      },
+      getSessionsByUserId: async (userId) => {
+        const records = await client
+          .select()
+          .from(session)
+          .where(eq(session.userId, userId))
+          .then((res) => res ?? []);
+
+        const resultRecords = records.map((record) => ({
+          id: record.id!,
+          active_expires: Number(record.activeExpires),
+          idle_expires: Number(record.idleExpires),
+          user_id: record.userId!,
+        }));
+
+        return resultRecords;
+      },
+      setSession: async (sessionData) => {
+        try {
+          const { active_expires, idle_expires, user_id, ...restSessionData } =
+            sessionData;
+          await client.insert(session).values({
+            ...restSessionData,
+            activeExpires: BigInt(active_expires),
+            idleExpires: BigInt(idle_expires),
+            userId: user_id,
+          });
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_INVALID_USER_ID");
+          throw error;
+        }
+      },
+      deleteSession: async (sessionId) => {
+        await client.delete(session).where(eq(session.id, sessionId));
+      },
+      deleteSessionsByUserId: async (userId) => {
+        await client.delete(session).where(eq(session.userId, userId));
+      },
+      updateSession: async (sessionId, partialSession) => {
+        try {
+          await client
+            .update(session)
+            .set({ ...partialSession })
+            .where(eq(session.id, sessionId));
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_INVALID_SESSION_ID");
+          throw error;
+        }
+      },
+      getKey: async (keyId) => {
+        const record = await client
+          .select()
+          .from(key)
+          .where(eq(key.id, keyId))
+          .then((res) => res[0] ?? null);
+
+        return {
+          hashed_password: record?.hashedPassword!,
+          user_id: record?.userId!,
+          id: record?.id!,
+        };
+      },
+      getKeysByUserId: async (userId) => {
+        const records = await client
+          .select()
+          .from(key)
+          .where(eq(key.userId, userId))
+          .then((res) => res ?? []);
+
+        const resultRecords = records.map((record) => {
+          return {
+            hashed_password: record.hashedPassword!,
+            user_id: record.userId!,
+            id: record.id!,
+          };
+        });
+
+        return resultRecords;
+      },
+      setKey: async (keyData) => {
+        try {
+          await client
+            .insert(key)
+            .values({ ...keyData, userId: keyData.user_id });
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_INVALID_USER_ID");
+          throw error;
+        }
+      },
+      deleteKey: async (keyId) => {
+        await client.delete(key).where(eq(key.id, keyId));
+      },
+      deleteKeysByUserId: async (userId) => {
+        await client.delete(key).where(eq(key.userId, userId));
+      },
+      updateKey: async (keyId, partialKey) => {
+        try {
+          const { hashed_password, user_id, ...restPartialKey } = partialKey;
+
+          if (hashed_password === undefined || user_id === undefined) {
+            throw new Error("Missing updateKey data");
+          }
+
+          await client
+            .update(key)
+            .set({
+              hashedPassword: hashed_password,
+              userId: user_id,
+              ...restPartialKey,
+            })
+            .where(eq(key.id, keyId));
+        } catch (e) {
+          const error = e as Partial<myDrizzleError>;
+          if (error.message?.includes("`id`"))
+            throw new luciaError("AUTH_INVALID_KEY_ID");
+          throw error;
+        }
+      },
+    };
+  };
+}

--- a/packages/adapter-drizzle/src/drizzle.ts
+++ b/packages/adapter-drizzle/src/drizzle.ts
@@ -1,0 +1,67 @@
+import type { Adapter, InitializeAdapter } from "lucia";
+
+import { MySqlDatabase } from "drizzle-orm/mysql-core";
+import { PgDatabase } from "drizzle-orm/pg-core";
+import { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
+import type { AnyMySqlTable, MySqlTableFn } from "drizzle-orm/mysql-core";
+import type { AnyPgTable, PgTableFn } from "drizzle-orm/pg-core";
+import type { AnySQLiteTable, SQLiteTableFn } from "drizzle-orm/sqlite-core";
+import { DrizzleError, is } from "drizzle-orm";
+
+import { mySqlDrizzleAdapter } from "./drivers/mysql.js";
+import { pgDrizzleAdapter } from "./drivers/pg.js";
+import { SQLiteDrizzleAdapter } from "./drivers/sqlite.js";
+
+export type AnyMySqlDatabase = MySqlDatabase<any, any>;
+export type AnyPgDatabase = PgDatabase<any, any, any>;
+export type AnySQLiteDatabase = BaseSQLiteDatabase<any, any, any, any>;
+
+export type SqlFlavorOptions =
+	| AnyMySqlDatabase
+	| AnyPgDatabase
+	| AnySQLiteDatabase;
+
+export type TableFn<Flavor> = Flavor extends AnyMySqlDatabase
+	? MySqlTableFn
+	: Flavor extends AnyPgDatabase
+	? PgTableFn
+	: Flavor extends AnySQLiteDatabase
+	? SQLiteTableFn
+	: AnySQLiteTable;
+
+export type myDrizzleError = InstanceType<typeof DrizzleError>;
+
+export function drizzleAdapter<SqlFlavor extends SqlFlavorOptions>(
+	db: SqlFlavor,
+	modelNames?: {
+		user: string;
+		session: string | null;
+		key: string;
+	},
+	table?: TableFn<SqlFlavor>
+): InitializeAdapter<Adapter> {
+	const getModelNames = () => {
+		if (!modelNames) {
+			return {
+				user: "auth_user",
+				session: "user_session",
+				key: "user_key"
+			};
+		}
+		return modelNames;
+	};
+
+	modelNames = getModelNames();
+
+	if (is(db, MySqlDatabase)) {
+		return mySqlDrizzleAdapter(db, table as MySqlTableFn, modelNames);
+	} else if (is(db, PgDatabase)) {
+		return pgDrizzleAdapter(db, table as PgTableFn, modelNames);
+	} else if (is(db, BaseSQLiteDatabase)) {
+		return SQLiteDrizzleAdapter(db, table as SQLiteTableFn, modelNames);
+	}
+
+	throw new Error(
+		`Unsupported database type (${typeof db}) in Drizzle adapter.`
+	);
+}

--- a/packages/adapter-drizzle/src/index.ts
+++ b/packages/adapter-drizzle/src/index.ts
@@ -1,0 +1,1 @@
+export { drizzleAdapter as drizzle } from "./drizzle.js";

--- a/packages/adapter-drizzle/src/lucia.d.ts
+++ b/packages/adapter-drizzle/src/lucia.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="lucia" />
+declare namespace Lucia {
+	type Auth = any;
+	type DatabaseUserAttributes = any;
+	type DatabaseSessionAttributes = any;
+}

--- a/packages/adapter-drizzle/test/index.ts
+++ b/packages/adapter-drizzle/test/index.ts
@@ -1,0 +1,13 @@
+import { testAdapter, Database } from "@lucia-auth/adapter-test";
+import type { QueryHandler, TableQueryHandler } from "@lucia-auth/adapter-test";
+import { LuciaError } from "lucia";
+
+import { drizzle } from "drizzle-orm/aws-data-api/pg";
+
+import { drizzleAdapter } from "../src/drizzle";
+
+const adapter = drizzleAdapter();
+
+await testAdapter(adapter, new Database());
+
+process.exit(0);

--- a/packages/adapter-drizzle/tsconfig.json
+++ b/packages/adapter-drizzle/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"noImplicitAny": true,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"target": "ES2022",
+		"allowSyntheticDefaultImports": true,
+		"declaration": true,
+		"outDir": "./dist",
+		"strict": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules/", "**/__tests__/*"]
+}


### PR DESCRIPTION
**WORK IN PROGRESS**

I really wanted Lucia Auth to have AWS Data API functionality, and I know drizzle does so I decided to spend the night hoping to hack something out.
I am no expert therefore this code was heavily inspired, and copy pasta'd from the following links. All credit should go to those authors and maintainers for [NextAuth DrizzleORM](https://github.com/nextauthjs/next-auth/tree/main/packages/adapter-drizzle) and [Lucia Auth Prisma](https://github.com/pilcrowOnPaper/lucia/tree/main/packages/adapter-prisma).

This code is extremely hacked together, and I am looking for any and all improvements, optimizations, suggestions, etc.. Please take the code, finish the adapter get it over the finish line.

The code has NOT been tested in any capacity, I am receiving module resolution errors when attempting to test within the monorepo.