### PR TITLE
Docs: NextJS Github OAuth <Form> -> <form> 

### DIFF
--- a/documentation/content/guidebook/github-oauth/$nextjs-app.md
+++ b/documentation/content/guidebook/github-oauth/$nextjs-app.md
@@ -366,7 +366,7 @@ const Form = ({
 }) => {
 	const router = useRouter();
 	return (
-		<Form
+		<form
 			action={action}
 			method="post"
 			onSubmit={async (e) => {
@@ -386,7 +386,7 @@ const Form = ({
 			}}
 		>
 			{children}
-		</Form>
+		</form>
 	);
 };
 


### PR DESCRIPTION
I believe this example was unintentionally defined as a JSX element, while it should've been just a regular html form element.