### PR TITLE
Strava OAuth provider

### DIFF
--- a/.auri/$4yx11wwf.md
+++ b/.auri/$4yx11wwf.md
@@ -1,6 +1,7 @@
 ---
 package: "@lucia-auth/oauth"
 type: "minor"
+pull: "988"
 ---
 
-Add AWS Cognito hosted UI provider
+Add AWS Cognito provider

--- a/.auri/$gmhkubg3.md
+++ b/.auri/$gmhkubg3.md
@@ -1,0 +1,6 @@
+---
+package: "@lucia-auth/oauth" # package name
+type: "minor" # "major", "minor", "patch"
+---
+
+Add Strava provider

--- a/documentation/content/oauth/index.md
+++ b/documentation/content/oauth/index.md
@@ -52,5 +52,6 @@ We also have framework specific guides.
 - Salesforce
 - Slack
 - Spotify
+- Strava
 - Twitch
 - Twitter

--- a/documentation/content/oauth/providers/strava.md
+++ b/documentation/content/oauth/providers/strava.md
@@ -86,25 +86,24 @@ type  =
 
 ```ts
 export type StravaUser = {
-  id: number;
-  username: string;
-  resource_state: number;
-  firstname: string;
-  lastname: string;
-  bio: string;
-  city: string;
-  country: string;
-  sex: string;
-  premium: boolean;
-  summit: boolean;
-  created_at: string;
-  updated_at: string;
-  badge_type_id: number;
-  weight: number;
-  profile_medium: string;
-  profile: string;
+	id: number;
+	username: string;
+	resource_state: number;
+	firstname: string;
+	lastname: string;
+	bio: string;
+	city: string;
+	country: string;
+	sex: string;
+	premium: boolean;
+	summit: boolean;
+	created_at: string;
+	updated_at: string;
+	badge_type_id: number;
+	weight: number;
+	profile_medium: string;
+	profile: string;
 };
-
 ```
 
 ### `StravaUserAuth`

--- a/documentation/content/oauth/providers/strava.md
+++ b/documentation/content/oauth/providers/strava.md
@@ -5,8 +5,6 @@ description: "Learn how to use the Strava OAuth provider"
 
 OAuth integration for Strava. Refer to [How To Create An Application](https://developers.strava.com/docs/getting-started/#account) for getting the required credentials. Provider id is `strava`.
 
-Note that as part of the payload of authenticating with Strava, a relatively rich User ('`athlete`') object is returned. This is used to populate the Strava id of the key, and can be used to populate many other fields at point of user creation without necessitating a second API call.
-
 ```ts
 import { strava } from "@lucia-auth/oauth/providers";
 import { auth } from "./lucia.js";

--- a/documentation/content/oauth/providers/strava.md
+++ b/documentation/content/oauth/providers/strava.md
@@ -1,0 +1,132 @@
+---
+title: "Strava"
+description: "Learn how to use the Strava OAuth provider"
+---
+
+OAuth integration for Strava. Refer to [How To Create An Application](https://developers.strava.com/docs/getting-started/#account) for getting the required credentials. Provider id is `strava`.
+
+Note that as part of the payload of authenticating with Strava, a relatively rich User ('`athlete`') object is returned. This is used to populate the Strava id of the key, and can be used to populate many other fields at point of user creation without necessitating a second API call.
+
+```ts
+import { strava } from "@lucia-auth/oauth/providers";
+import { auth } from "./lucia.js";
+
+const stravaAuth = strava(auth, config);
+```
+
+## `strava()`
+
+```ts
+const strava: (
+	auth: Auth,
+	config: {
+		clientId: string;
+		clientSecret: string;
+		scope?: string[];
+		redirectUri?: string;
+	}
+) => GithubProvider;
+```
+
+##### Parameters
+
+| name                  | type                                       | description                    | optional |
+| --------------------- | ------------------------------------------ | ------------------------------ | :------: |
+| `auth`                | [`Auth`](/reference/lucia/interfaces/auth) | Lucia instance                 |          |
+| `config.clientId`     | `string`                                   | Strava OAuth app client id     |          |
+| `config.clientSecret` | `string`                                   | Strava OAuth app client secret |          |
+| `config.scope`        | `string[]`                                 | an array of scopes             |    ✓     |
+| `configs.redirectUri` | `string`                                   | an authorized redirect URI     |    ✓     |
+
+##### Returns
+
+| type                                | description     |
+| ----------------------------------- | --------------- |
+| [`StravaProvider`](#stravaprovider) | Strava provider |
+
+## Interfaces
+
+### `StravaAuth`
+
+See [`OAuth2ProviderAuth`](/reference/oauth/interfaces/oauth2providerauth).
+
+```ts
+// implements OAuth2ProviderAuth<GithubAuth<_Auth>>
+interface StravaAuth<_Auth extends Auth> {
+	getAuthorizationUrl: () => Promise<readonly [url: URL, state: string]>;
+	validateCallback: (code: string) => Promise<StravaUserAuth<_Auth>>;
+}
+```
+
+| type                                |
+| ----------------------------------- |
+| [`StravaUserAuth`](#stravauserauth) |
+
+##### Generics
+
+| name    | extends                                    | default |
+| ------- | ------------------------------------------ | ------- |
+| `_Auth` | [`Auth`](/reference/lucia/interfaces/auth) | `Auth`  |
+
+### `StravaTokens`
+
+```ts
+type  =
+  | {
+    accessToken: string;
+    user: StravaUser;
+  }
+	| {
+    accessToken: string;
+    refreshToken: string;
+    accessTokenExpiresIn: number;
+    user: StravaUser;
+  };
+```
+
+### `StravaUser`
+
+```ts
+export type StravaUser = {
+  id: number;
+  username: string;
+  resource_state: number;
+  firstname: string;
+  lastname: string;
+  bio: string;
+  city: string;
+  country: string;
+  sex: string;
+  premium: boolean;
+  summit: boolean;
+  created_at: string;
+  updated_at: string;
+  badge_type_id: number;
+  weight: number;
+  profile_medium: string;
+  profile: string;
+};
+
+```
+
+### `StravaUserAuth`
+
+Extends [`ProviderUserAuth`](/reference/oauth/interfaces/provideruserauth).
+
+```ts
+interface Auth0UserAuth<_Auth extends Auth> extends ProviderUserAuth<_Auth> {
+	stravaUser: StravaUser;
+	stravaTokens: StravaTokens;
+}
+```
+
+| properties     | type                            | description       |
+| -------------- | ------------------------------- | ----------------- |
+| `stravaUser`   | [`StravaUser`](#stravauser)     | Strava user       |
+| `stravaTokens` | [`StravaTokens`](#stravatokens) | Access tokens etc |
+
+##### Generics
+
+| name    | extends                                    |
+| ------- | ------------------------------------------ |
+| `_Auth` | [`Auth`](/reference/lucia/interfaces/auth) |

--- a/documentation/content/reference/oauth/modules/providers.md
+++ b/documentation/content/reference/oauth/modules/providers.md
@@ -86,6 +86,10 @@ See [Slack](/oauth/providers/slack) provider.
 
 See [Spotify](/oauth/providers/spotify) provider.
 
+## `strava()`
+
+See [Strava](/oauth/providers/strava) provider.
+
 ## `twitch()`
 
 See [Twitch](/oauth/providers/twitch) provider.

--- a/documentation/src/components/menus/OAuthMenu.astro
+++ b/documentation/src/components/menus/OAuthMenu.astro
@@ -41,6 +41,7 @@ import Menu from "./Menu.astro";
 				["Salesforce", "/oauth/providers/salesforce"],
 				["Slack", "/oauth/providers/slack"],
 				["Spotify", "/oauth/providers/spotify"],
+				["Strava", "/oauth/providers/strava"],
 				["Twitch", "/oauth/providers/twitch"],
 				["Twitter", "/oauth/providers/twitter"]
 			]

--- a/packages/oauth/src/providers/index.ts
+++ b/packages/oauth/src/providers/index.ts
@@ -159,6 +159,14 @@ export type {
 	SpotifyUserAuth
 } from "./spotify.js";
 
+export { strava } from "./strava.js";
+export type {
+	StravaAuth,
+	StravaTokens,
+	StravaUser,
+	StravaUserAuth
+} from "./strava.js";
+
 export { twitch } from "./twitch.js";
 export type {
 	TwitchAuth,

--- a/packages/oauth/src/providers/strava.ts
+++ b/packages/oauth/src/providers/strava.ts
@@ -1,0 +1,145 @@
+import {
+	OAuth2ProviderAuth,
+	createOAuth2AuthorizationUrl,
+	validateOAuth2AuthorizationCode
+} from "../core/oauth2.js";
+import { ProviderUserAuth } from "../core/provider.js";
+
+import type { Auth } from "lucia";
+
+type Config = {
+	clientId: string;
+	clientSecret: string;
+	scope?: string[];
+	redirectUri?: string;
+};
+
+const PROVIDER_ID = "strava";
+
+export const strava = <_Auth extends Auth = Auth>(
+	auth: _Auth,
+	config: Config
+): StravaAuth<_Auth> => {
+	return new StravaAuth(auth, config);
+};
+
+export class StravaAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuth<
+	StravaUserAuth<_Auth>
+> {
+	private config: Config;
+
+	constructor(auth: _Auth, config: Config) {
+		super(auth);
+
+		this.config = config;
+	}
+
+	public getAuthorizationUrl = async (): Promise<
+		readonly [url: URL, state: string]
+	> => {
+		return await createOAuth2AuthorizationUrl(
+			"https://www.strava.com/oauth/authorize",
+			{
+				clientId: this.config.clientId,
+				scope: this.config.scope ?? ['read'],
+				redirectUri: this.config.redirectUri
+			}
+		);
+	};
+
+	public validateCallback = async (
+		code: string
+	): Promise<StravaUserAuth<_Auth>> => {
+		const stravaTokens = await this.validateAuthorizationCode(code);
+		const stravaUser = stravaTokens.user;
+		return new StravaUserAuth(this.auth, stravaUser, stravaTokens);
+	};
+
+	private validateAuthorizationCode = async (
+		code: string
+	): Promise<StravaTokens> => {
+		const tokens =
+			await validateOAuth2AuthorizationCode<AccessTokenResponseBody>(
+				code,
+				"https://www.strava.com/oauth/token",
+				{
+					clientId: this.config.clientId,
+					clientPassword: {
+						clientSecret: this.config.clientSecret,
+						authenticateWith: "client_secret"
+					}
+				}
+			);
+		if ("refresh_token" in tokens) {
+			return {
+				accessToken: tokens.access_token,
+				accessTokenExpiresIn: tokens.expires_in,
+				refreshToken: tokens.refresh_token,
+        user: tokens.athlete
+			};
+		}
+		return {
+			accessToken: tokens.access_token,
+      user: tokens.athlete
+		};
+	};
+}
+
+export class StravaUserAuth<
+	_Auth extends Auth
+> extends ProviderUserAuth<_Auth> {
+	public stravaTokens: StravaTokens;
+	public stravaUser: StravaUser;
+
+	constructor(auth: _Auth, stravaUser: StravaUser, stravaTokens: StravaTokens) {
+		super(auth, PROVIDER_ID, stravaUser.id.toString());
+
+		this.stravaTokens = stravaTokens;
+		this.stravaUser = stravaUser;
+	}
+}
+
+type AccessTokenResponseBody =
+	| {
+			access_token: string;
+      athlete: StravaUser
+	  }
+	| {
+			access_token: string;
+			refresh_token: string;
+			expires_in: number;
+			expires_at: number;
+      athlete: StravaUser
+	  };
+
+export type StravaTokens =
+  | {
+    accessToken: string;
+    user: StravaUser;
+  }
+	| {
+    accessToken: string;
+    refreshToken: string;
+    accessTokenExpiresIn: number;
+    user: StravaUser;
+  };
+
+export type StravaUser = {
+  id: number;
+  username: string;
+  resource_state: number;
+  firstname: string;
+  lastname: string;
+  bio: string;
+  city: string;
+  country: string;
+  sex: string;
+  premium: boolean;
+  summit: boolean;
+  created_at: string;
+  updated_at: string;
+  badge_type_id: number;
+  weight: number;
+  profile_medium: string;
+  profile: string;
+};

--- a/packages/oauth/src/providers/strava.ts
+++ b/packages/oauth/src/providers/strava.ts
@@ -41,7 +41,7 @@ export class StravaAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuth<
 			"https://www.strava.com/oauth/authorize",
 			{
 				clientId: this.config.clientId,
-				scope: this.config.scope ?? ['read'],
+				scope: this.config.scope ?? ["read"],
 				redirectUri: this.config.redirectUri
 			}
 		);
@@ -50,14 +50,16 @@ export class StravaAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuth<
 	public validateCallback = async (
 		code: string
 	): Promise<StravaUserAuth<_Auth>> => {
-		const [stravaUser, stravaTokens] = await this.validateAuthorizationCode(code);
+		const [stravaUser, stravaTokens] = await this.validateAuthorizationCode(
+			code
+		);
 		return new StravaUserAuth(this.auth, stravaUser, stravaTokens);
 	};
 
 	private validateAuthorizationCode = async (
 		code: string
 	): Promise<[StravaUser, StravaTokens]> => {
-		const {athlete:user, ...tokens} =
+		const { athlete: user, ...tokens } =
 			await validateOAuth2AuthorizationCode<AccessTokenResponseBody>(
 				code,
 				"https://www.strava.com/oauth/token",
@@ -70,19 +72,21 @@ export class StravaAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuth<
 				}
 			);
 		if ("refresh_token" in tokens) {
-			return [user,
-        {
-          accessToken: tokens.access_token,
-          accessTokenExpiresIn: tokens.expires_in,
-          refreshToken: tokens.refresh_token,
-        }
+			return [
+				user,
+				{
+					accessToken: tokens.access_token,
+					accessTokenExpiresIn: tokens.expires_in,
+					refreshToken: tokens.refresh_token
+				}
 			];
 		}
-		return [user,
-      {
-        accessToken: tokens.access_token,
-      }
-    ]
+		return [
+			user,
+			{
+				accessToken: tokens.access_token
+			}
+		];
 	};
 }
 
@@ -103,42 +107,42 @@ export class StravaUserAuth<
 type AccessTokenResponseBody =
 	| {
 			access_token: string;
-      athlete: StravaUser;
+			athlete: StravaUser;
 	  }
 	| {
 			access_token: string;
 			refresh_token: string;
 			expires_in: number;
 			expires_at: number;
-      athlete: StravaUser
+			athlete: StravaUser;
 	  };
 
 export type StravaTokens =
-  | {
-    accessToken: string;
-  }
 	| {
-    accessToken: string;
-    refreshToken: string;
-    accessTokenExpiresIn: number;
-  };
+			accessToken: string;
+	  }
+	| {
+			accessToken: string;
+			refreshToken: string;
+			accessTokenExpiresIn: number;
+	  };
 
 export type StravaUser = {
-  id: number;
-  username: string;
-  resource_state: number;
-  firstname: string;
-  lastname: string;
-  bio: string;
-  city: string;
-  country: string;
-  sex: string;
-  premium: boolean;
-  summit: boolean;
-  created_at: string;
-  updated_at: string;
-  badge_type_id: number;
-  weight: number;
-  profile_medium: string;
-  profile: string;
+	id: number;
+	username: string;
+	resource_state: number;
+	firstname: string;
+	lastname: string;
+	bio: string;
+	city: string;
+	country: string;
+	sex: string;
+	premium: boolean;
+	summit: boolean;
+	created_at: string;
+	updated_at: string;
+	badge_type_id: number;
+	weight: number;
+	profile_medium: string;
+	profile: string;
 };

--- a/packages/oauth/src/providers/strava.ts
+++ b/packages/oauth/src/providers/strava.ts
@@ -58,7 +58,7 @@ export class StravaAuth<_Auth extends Auth = Auth> extends OAuth2ProviderAuth<
 
 	private validateAuthorizationCode = async (
 		code: string
-	): Promise<[StravaUser, StravaTokens]> => {
+	): Promise<[stravaUser: StravaUser, stravaTokens: StravaTokens]> => {
 		const { athlete: user, ...tokens } =
 			await validateOAuth2AuthorizationCode<AccessTokenResponseBody>(
 				code,


### PR DESCRIPTION
Strava provides a simple/straightforward OAuth provider, with just enough documentation to get it together. Heavily based on the Github example, obviously, this makes life a lot easier if you're one of the handful of people developing a Strava-based app.

I don't have anything resembling test coverage for this - wasn't sure where it should be - but I have tested this manually locally.