### PR TITLE
Docs: Fix sveltekit github-oauth login redirection file path

### DIFF
--- a/documentation/content/guidebook/github-oauth/$sveltekit.md
+++ b/documentation/content/guidebook/github-oauth/$sveltekit.md
@@ -256,7 +256,7 @@ const user = await getUser();
 
 ## Redirect authenticated users
 
-Define a server load function in `routes/signup/+page.server.ts`.
+Define a server load function in `routes/login/+page.server.ts`.
 
 Authenticated users should be redirected to the profile page whenever they try to access the sign in page. You can validate requests by creating a new [`AuthRequest` instance](/reference/lucia/interfaces/authrequest) with [`Auth.handleRequest()`](/reference/lucia/interfaces/auth#handlerequest), which is stored in `locals.auth`, and calling [`AuthRequest.validate()`](/reference/lucia/interfaces/authrequest#validate). This method returns a [`Session`](/reference/lucia/interfaces#session) if the user is authenticated or `null` if not.
 


### PR DESCRIPTION
Fixes the github-oauth login redirection file path to match with code example provided for sveltekit