### PR TITLE
Docs: Fix userId assignment

### DIFF
--- a/documentation/content/guidebook/email-verification-links/index.md
+++ b/documentation/content/guidebook/email-verification-links/index.md
@@ -291,7 +291,7 @@ post("/login", async (request: Request) => {
 		// and validate password
 		const key = await auth.useKey("email", email.toLowerCase(), password);
 		const session = await auth.createSession({
-			userId: user.userId,
+			userId: key.userId,
 			attributes: {}
 		});
 		const sessionCookie = auth.createSessionCookie(session);

--- a/documentation/content/guidebook/sign-in-with-username-and-password/$express.md
+++ b/documentation/content/guidebook/sign-in-with-username-and-password/$express.md
@@ -213,7 +213,7 @@ app.post("/login", async (req, res) => {
 		// and validate password
 		const key = await auth.useKey("username", username.toLowerCase(), password);
 		const session = await auth.createSession({
-			userId: user.userId,
+			userId: key.userId,
 			attributes: {}
 		});
 		const authRequest = auth.handleRequest(req, res);

--- a/documentation/content/guidebook/sign-in-with-username-and-password/$hono.md
+++ b/documentation/content/guidebook/sign-in-with-username-and-password/$hono.md
@@ -189,7 +189,7 @@ app.post("/login", async (context) => {
 		// and validate password
 		const key = await auth.useKey("username", username.toLowerCase(), password);
 		const session = await auth.createSession({
-			userId: user.userId,
+			userId: key.userId,
 			attributes: {}
 		});
 		const authRequest = auth.handleRequest(context);

--- a/documentation/content/guidebook/sign-in-with-username-and-password/$nextjs-app.md
+++ b/documentation/content/guidebook/sign-in-with-username-and-password/$nextjs-app.md
@@ -409,7 +409,7 @@ export const POST = async (request: NextRequest) => {
 		// and validate password
 		const key = await auth.useKey("username", username.toLowerCase(), password);
 		const session = await auth.createSession({
-			userId: user.userId,
+			userId: key.userId,
 			attributes: {}
 		});
 		const authRequest = auth.handleRequest({

--- a/documentation/content/guidebook/sign-in-with-username-and-password/$nextjs-pages.md
+++ b/documentation/content/guidebook/sign-in-with-username-and-password/$nextjs-pages.md
@@ -365,7 +365,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 		// and validate password
 		const key = await auth.useKey("username", username.toLowerCase(), password);
 		const session = await auth.createSession({
-			userId: user.userId,
+			userId: key.userId,
 			attributes: {}
 		});
 		const authRequest = auth.handleRequest({

--- a/documentation/content/guidebook/sign-in-with-username-and-password/$nuxt.md
+++ b/documentation/content/guidebook/sign-in-with-username-and-password/$nuxt.md
@@ -286,7 +286,7 @@ export default defineEventHandler(async (event) => {
 		// and validate password
 		const key = await auth.useKey("username", username.toLowerCase(), password);
 		const session = await auth.createSession({
-			userId: user.userId,
+			userId: key.userId,
 			attributes: {}
 		});
 		const authRequest = auth.handleRequest(event);

--- a/documentation/content/guidebook/sign-in-with-username-and-password/index.md
+++ b/documentation/content/guidebook/sign-in-with-username-and-password/index.md
@@ -222,7 +222,7 @@ post("/login", async (request: Request) => {
 		// and validate password
 		const key = await auth.useKey("username", username.toLowerCase(), password);
 		const session = await auth.createSession({
-			userId: user.userId,
+			userId: key.userId,
 			attributes: {}
 		});
 		const sessionCookie = auth.createSessionCookie(session);


### PR DESCRIPTION
This PR fixes an issue where the `userId` assignment in the `createSession` call was incorrect in documentation. It has been updated to use `key.userId` instead of `user.userId`.