### PR TITLE
Pin Node version for Github actions

### DIFF
--- a/.github/workflows/auri.yaml
+++ b/.github/workflows/auri.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 20.5.1
           registry-url: https://registry.npmjs.org
       - name: install dependencies
         run: |


### PR DESCRIPTION
Seems Nuxt is broken with Node 20.6 https://github.com/nuxt/nuxt/issues/23020