### PR TITLE
Fix `Auth.handleRequest()` breaking app in Next.js middleware

### DIFF
--- a/.auri/$x7ntu107.md
+++ b/.auri/$x7ntu107.md
@@ -1,0 +1,6 @@
+---
+package: "lucia" # package name
+type: "patch" # "major", "minor", "patch"
+---
+
+Fix `Auth.handleRequest()` causing error in middleware when `nextjs()` was used 

--- a/packages/lucia/src/middleware/index.ts
+++ b/packages/lucia/src/middleware/index.ts
@@ -325,9 +325,12 @@ export const nextjs = (): Middleware<
 	return ({ args, sessionCookieName, env }) => {
 		const [serverContext] = args;
 
-		if ("request" in serverContext || "cookies" in serverContext) {
+		if ("cookies" in serverContext) {
+			// for some reason `"request" in NextRequest` returns true???
 			const request =
-				"request" in serverContext ? serverContext.request : serverContext;
+				typeof serverContext.cookies === "function"
+					? (serverContext as NextJsAppServerContext).request
+					: (serverContext as NextRequest);
 
 			const readonlyCookieStore =
 				typeof serverContext.cookies === "function"
@@ -336,7 +339,6 @@ export const nextjs = (): Middleware<
 
 			const sessionCookie =
 				readonlyCookieStore.get(sessionCookieName)?.value ?? null;
-
 			const requestContext = {
 				request: {
 					url: request?.url ?? "",
@@ -359,7 +361,6 @@ export const nextjs = (): Middleware<
 					}
 				}
 			} as const satisfies RequestContext;
-
 			return requestContext;
 		}
 


### PR DESCRIPTION
Closes #1063 

Looks like `"request" in NextRequest` returns `true` for some reason. `Object.keys()` doesn't help either. No idea what's happening under the hood. 