### PR TITLE
Docs: Fix function footprint for getAllUserSessions

### DIFF
--- a/documentation/content/reference/lucia/interfaces/auth.md
+++ b/documentation/content/reference/lucia/interfaces/auth.md
@@ -301,7 +301,7 @@ const keys = await auth.getAllUserKeys(userId);
 Validate the user id and get all valid sessions of a user. Includes active and idle sessions, but not dead sessions.
 
 ```ts
-const getAllUserKeys: (userId: string) => Promise<Session[]>;
+const getAllUserSessions: (userId: string) => Promise<Session[]>;
 ```
 
 ##### Parameters


### PR DESCRIPTION
The getAllUserSessions method shows getAllUserKeys instead of getAllUserSessions

<img width="905" alt="image" src="https://github.com/pilcrowOnPaper/lucia/assets/46068081/cd852a95-1d0e-4742-a177-de852490fdb2">
