### PR TITLE
change all references of Gitlab -> GitLab

### DIFF
--- a/documentation/content/oauth/index.md
+++ b/documentation/content/oauth/index.md
@@ -42,7 +42,7 @@ We also have framework specific guides.
 - Dropbox
 - Facebook
 - Github
-- Gitlab
+- GitLab
 - Google
 - Lichess
 - Line

--- a/documentation/content/oauth/providers/gitlab.md
+++ b/documentation/content/oauth/providers/gitlab.md
@@ -1,9 +1,9 @@
 ---
-title: "Gitlab OAuth provider"
-description: "Learn how to use the Gitlab OAuth provider"
+title: "GitLab OAuth provider"
+description: "Learn how to use the GitLab OAuth provider"
 ---
 
-OAuth integration for Gitlab. Provider id is `gitlab`.
+OAuth integration for GitLab. Provider id is `gitlab`.
 
 ```ts
 import { gitlab } from "@lucia-auth/oauth/providers";
@@ -33,8 +33,8 @@ const gitlab: (
 | name                   | type                                       | description                    | optional |
 | ---------------------- | ------------------------------------------ | ------------------------------ | :------: |
 | `auth`                 | [`Auth`](/reference/lucia/interfaces/auth) | Lucia instance                 |          |
-| `configs.clientId`     | `string`                                   | Gitlab OAuth app client id     |          |
-| `configs.clientSecret` | `string`                                   | Gitlab OAuth app client secret |          |
+| `configs.clientId`     | `string`                                   | GitLab OAuth app client id     |          |
+| `configs.clientSecret` | `string`                                   | GitLab OAuth app client secret |          |
 | `configs.redirectUri`  | `string`                                   | an authorized redirect URI     |          |
 | `configs.scope`        | `string[]`                                 | an array of scopes             |    ✓     |
 
@@ -42,7 +42,7 @@ const gitlab: (
 
 | type                                | description     |
 | ----------------------------------- | --------------- |
-| [`GitlabProvider`](#gitlabprovider) | Gitlab provider |
+| [`GitlabProvider`](#gitlabprovider) | GitLab provider |
 
 ## Interfaces
 
@@ -135,7 +135,7 @@ interface GitlabUserAuth<_Auth extends Auth> extends ProviderUserAuth<_Auth> {
 
 | properties     | type                            | description       |
 | -------------- | ------------------------------- | ----------------- |
-| `gitlabUser`   | [`GitlabUser`](#gitlabuser)     | Gitlab user       |
+| `gitlabUser`   | [`GitlabUser`](#gitlabuser)     | GitLab user       |
 | `gitlabTokens` | [`GitlabTokens`](#gitlabtokens) | Access tokens etc |
 
 ##### Generics

--- a/documentation/content/reference/oauth/modules/providers.md
+++ b/documentation/content/reference/oauth/modules/providers.md
@@ -44,7 +44,7 @@ See [Github](/oauth/providers/github) provider.
 
 ## `gitlab()`
 
-See [Gitlab](/oauth/providers/gitlab) provider.
+See [GitLab](/oauth/providers/gitlab) provider.
 
 ## `google()`
 

--- a/documentation/src/components/menus/OAuthMenu.astro
+++ b/documentation/src/components/menus/OAuthMenu.astro
@@ -30,7 +30,7 @@ import Menu from "./Menu.astro";
 				["Dropbox", "/oauth/providers/dropbox"],
 				["Facebook", "/oauth/providers/facebook"],
 				["Github", "/oauth/providers/github"],
-				["Gitlab", "/oauth/providers/gitlab"],
+				["GitLab", "/oauth/providers/gitlab"],
 				["Google", "/oauth/providers/google"],
 				["Lichess", "/oauth/providers/lichess"],
 				["Line", "/oauth/providers/line"],

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 - [#1015](https://github.com/pilcrowOnPaper/lucia/pull/1015) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Line provider
 
-- [#1013](https://github.com/pilcrowOnPaper/lucia/pull/1013) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Gitlab provider
+- [#1013](https://github.com/pilcrowOnPaper/lucia/pull/1013) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add GitLab provider
 
 - [#1017](https://github.com/pilcrowOnPaper/lucia/pull/1017) by [@pilcrowOnPaper](https://github.com/pilcrowOnPaper) : Add Bitbucket provider
 


### PR DESCRIPTION
Changes all references of "Gitlab" to "GitLab" in content pages. This does not update function or method names. Figured I'd update this one as well while I was in here 🙂 