### PR TITLE
change all references of "(AWS) Cognito" -> "Amazon Cognito"

### DIFF
--- a/documentation/content/oauth/index.md
+++ b/documentation/content/oauth/index.md
@@ -37,7 +37,7 @@ We also have framework specific guides.
 - Azure Active Directory
 - Bitbucket
 - Box
-- Cognito
+- Amazon Cognito
 - Discord
 - Dropbox
 - Facebook

--- a/documentation/content/oauth/providers/cognito.md
+++ b/documentation/content/oauth/providers/cognito.md
@@ -1,9 +1,9 @@
 ---
-title: "AWS Cognito OAuth provider"
-description: "Learn about using the AWS Cognito provider"
+title: "Amazon Cognito OAuth provider"
+description: "Learn about using the Amazon Cognito provider"
 ---
 
-OAuth integration for AWS Cognito's hosted UI. Refer to the Cognito docs:
+OAuth integration for Amazon Cognito's hosted UI. Refer to the Cognito docs:
 
 - [Amazon Cognito hosted UI](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-integration.html)
 - [Authorization endpoint documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html)
@@ -42,7 +42,7 @@ const cognito: (
 | `config.clientSecret`   | `string`                                   | Cognito app client secret                        |          |
 | `configs.redirectUri`   | `string`                                   | an authorized redirect URI                       |          |
 | `config.scope`          | `string[]`                                 | an array of scopes - `openid` is always included |    ✓     |
-| `config.userPoolDomain` | `string`                                   | AWS Cognito's user pool domain                   |          |
+| `config.userPoolDomain` | `string`                                   | Amazon Cognito's user pool domain                |          |
 
 ##### Returns
 

--- a/documentation/src/components/menus/OAuthMenu.astro
+++ b/documentation/src/components/menus/OAuthMenu.astro
@@ -25,7 +25,7 @@ import Menu from "./Menu.astro";
 				["Azure Active Directory", "/oauth/providers/azure-ad"],
 				["Bitbucket", "/oauth/providers/bitbucket"],
 				["Box", "/oauth/providers/box"],
-				["Cognito", "/oauth/providers/cognito"],
+				["Amazon Cognito", "/oauth/providers/cognito"],
 				["Discord", "/oauth/providers/discord"],
 				["Dropbox", "/oauth/providers/dropbox"],
 				["Facebook", "/oauth/providers/facebook"],


### PR DESCRIPTION
Changes all references of "(AWS) Cognito" to "[Amazon Cognito](https://aws.amazon.com/cognito/)" in content pages. This does not update function or method names.