### PR TITLE
Fix `apple()` provider and docs

### DIFF
--- a/.auri/$ku1jk5lf.md
+++ b/.auri/$ku1jk5lf.md
@@ -1,0 +1,6 @@
+---
+package: "lucia" # package name
+type: "minor" # "major", "minor", "patch"
+---
+
+Add `options.responseMode` params to `apple()`

--- a/documentation/content/oauth/basics/oauth2.md
+++ b/documentation/content/oauth/basics/oauth2.md
@@ -48,7 +48,7 @@ url.searchParams.set("response_mode", "query");
 
 ### Validate callback
 
-Upon authentication, the provider will redirect the user back to your application. The url includes a code, and a state if the provider supports it. If a state is used, make sure to check if the state in the query params is the same as the one stored as a cookie.
+Upon authentication, the provider will redirect the user back to your application (GET request). The url includes a code, and a state if the provider supports it. If a state is used, make sure to check if the state in the query params is the same as the one stored as a cookie.
 
 Validate the code using `validateCallback()`. If the code is valid, this will return a new [`ProviderUserAuth`](/reference/oauth/interfaces#provideruserauth) among provider specific items (such as provider user data and access tokens). See [Handle users with OAuth](/oauth/basics/handle-users) for how to use it.
 

--- a/documentation/content/oauth/providers/apple.md
+++ b/documentation/content/oauth/providers/apple.md
@@ -36,22 +36,24 @@ const apple: (
 		teamId: string;
 		keyId: string;
 		certificate: string;
-		scope: string[];
+		scope?: string[];
+		responseMode?: "query" | "form_post";
 	}
 ) => AppleProvider;
 ```
 
 ##### Parameters
 
-| name                 | type                                       | description                                                    | optional |
-| -------------------- | ------------------------------------------ | -------------------------------------------------------------- | :------: |
-| `auth`               | [`Auth`](/reference/lucia/interfaces/auth) | Lucia instance                                                 |          |
-| `config.clientId`    | `string`                                   | Apple service identifier                                       |          |
-| `config.redirectUri` | `string`                                   | an authorized redirect URI                                     |          |
-| `config.teamId`      | `string`                                   | Apple teamId                                                   |          |
-| `config.keyId `      | `string`                                   | Apple private keyId                                            |          |
-| `config.certificate` | `string`                                   | p8 certificate as string [See how](#how-to-import-certificate) |          |
-| `config.scope`       | `string[]`                                 | an array of scopes                                             |    ✓     |
+| name                  | type                                       | description                                                         | default   |
+| --------------------- | ------------------------------------------ | ------------------------------------------------------------------- | --------- |
+| `auth`                | [`Auth`](/reference/lucia/interfaces/auth) | Lucia instance                                                      |           |
+| `config.clientId`     | `string`                                   | Apple service identifier                                            |           |
+| `config.redirectUri`  | `string`                                   | an authorized redirect URI                                          |           |
+| `config.teamId`       | `string`                                   | Apple teamId                                                        |           |
+| `config.keyId `       | `string`                                   | Apple private keyId                                                 |           |
+| `config.certificate`  | `string`                                   | p8 certificate as string [See how](#how-to-import-certificate)      |           |
+| `config.scope`        | `string[]`                                 | an array of scopes                                                  | `[]`      |
+| `config.responseMode` | `"query" \| "form_post"`                   | OIDC response mode - **must be `form_post` when requesting scopes** | `"query"` |
 
 ##### Returns
 

--- a/documentation/content/oauth/providers/apple.md
+++ b/documentation/content/oauth/providers/apple.md
@@ -44,16 +44,16 @@ const apple: (
 
 ##### Parameters
 
-| name                  | type                                       | description                                                         | default   |
-| --------------------- | ------------------------------------------ | ------------------------------------------------------------------- | --------- |
-| `auth`                | [`Auth`](/reference/lucia/interfaces/auth) | Lucia instance                                                      |           |
-| `config.clientId`     | `string`                                   | Apple service identifier                                            |           |
-| `config.redirectUri`  | `string`                                   | an authorized redirect URI                                          |           |
-| `config.teamId`       | `string`                                   | Apple teamId                                                        |           |
-| `config.keyId `       | `string`                                   | Apple private keyId                                                 |           |
-| `config.certificate`  | `string`                                   | p8 certificate as string [See how](#how-to-import-certificate)      |           |
-| `config.scope`        | `string[]`                                 | an array of scopes                                                  | `[]`      |
-| `config.responseMode` | `"query" \| "form_post"`                   | OIDC response mode - **must be `form_post` when requesting scopes** | `"query"` |
+| name                  | type                                       | description                                                           | default   |
+| --------------------- | ------------------------------------------ | --------------------------------------------------------------------- | --------- |
+| `auth`                | [`Auth`](/reference/lucia/interfaces/auth) | Lucia instance                                                        |           |
+| `config.clientId`     | `string`                                   | Apple service identifier                                              |           |
+| `config.redirectUri`  | `string`                                   | an authorized redirect URI                                            |           |
+| `config.teamId`       | `string`                                   | Apple teamId                                                          |           |
+| `config.keyId `       | `string`                                   | Apple private keyId                                                   |           |
+| `config.certificate`  | `string`                                   | p8 certificate as string [See how](#how-to-import-certificate)        |           |
+| `config.scope`        | `string[]`                                 | an array of scopes                                                    | `[]`      |
+| `config.responseMode` | `"query" \| "form_post"`                   | OIDC response mode - **must be `"form_post"` when requesting scopes** | `"query"` |
 
 ##### Returns
 

--- a/documentation/content/oauth/providers/apple.md
+++ b/documentation/content/oauth/providers/apple.md
@@ -51,7 +51,7 @@ const apple: (
 | `config.teamId`      | `string`                                   | Apple teamId                                                   |          |
 | `config.keyId `      | `string`                                   | Apple private keyId                                            |          |
 | `config.certificate` | `string`                                   | p8 certificate as string [See how](#how-to-import-certificate) |          |
-| `config.scope`      | `string[]`                                 | an array of scopes                                             |    ✓     |
+| `config.scope`       | `string[]`                                 | an array of scopes                                             |    ✓     |
 
 ##### Returns
 
@@ -81,6 +81,33 @@ export const appleAuth = apple(auth, {
 	redirectUri: process.env.APPLE_REDIRECT_URI ?? "",
 	clientId: process.env.APPLE_CLIENT_ID ?? ""
 });
+```
+
+## Requesting scopes
+
+When requesting scopes (`email` and `name`), the `options.responseMode` must be set to `"form_post"`. Unlike the default `"query"` response mode, \*\*Apple will send an `application/x-www-form-urlencoded` POST request. You can retrieve the code by parsing the search queries or the form data.
+
+```ts
+post("/login/apple/callback", async (request) => {
+	const url = new URL(request.url)
+	const code = url.searchParams.get("code");
+	if (!isValidState(request, code)) {
+		// ...
+	}
+	const appleUserAuth = await
+	// ...
+})
+```
+
+Apple will also include a `user` field **only in the first response**, where you can access the user's name.
+
+```ts
+const url = new URL(request.url);
+const userJSON = url.searchParams.get("user");
+if (userJSON) {
+	const user = JSON.parse(userJSON);
+	const { firstName, lastName, email } = user;
+}
 ```
 
 ## Interfaces
@@ -124,10 +151,6 @@ type AppleTokens = {
 type AppleUser = {
 	email?: string;
 	email_verified?: boolean;
-	name?: {
-		firstName: string;
-		lastName: string;
-	};
 	sub: string;
 };
 ```

--- a/examples/tauri/github-oauth/app/index.html
+++ b/examples/tauri/github-oauth/app/index.html
@@ -17,7 +17,7 @@
 			</div>
 			<div>
 				<button id="login-button">Sign in with GitHub</button>
-        <button id="logout-button">Sign out</button>
+				<button id="logout-button">Sign out</button>
 			</div>
 		</div>
 	</body>


### PR DESCRIPTION
Apple requires `form_post` response mode instead of `query` when requesting scopes. The `user` field is also in the callback, and not from the token endpoint.